### PR TITLE
🐛 Fix kube config yaml output for gke clusters

### DIFF
--- a/plugins/modules/gcp_container_cluster.py
+++ b/plugins/modules/gcp_container_cluster.py
@@ -1643,7 +1643,7 @@ class Kubectl(object):
             self.module.fail_json(msg="Please install the pyyaml module")
 
         with open(self.module.params['kubectl_path'], 'w') as f:
-            f.write(yaml.dump(self._contents()))
+            f.write(yaml.safe_dump(self._contents()))
 
     """
     Returns the contents of a kubectl file


### PR DESCRIPTION
This change fixes an issue with the `gcp_container_cluster` module where
resulting kubectl configurations were invalid due to improper use of
PyYaml. By using PyYaml's `safe_dump` method, the resulting kubectl
config file will no longer contain Python object tags.

Fix #182

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`gcp_container_cluster`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
(see #182 for info)
