### PR TITLE
gcsfuse role for GCP Storage mounting

### DIFF
--- a/roles/gcsfuse/README.md
+++ b/roles/gcsfuse/README.md
@@ -1,0 +1,31 @@
+# gcsfuse
+
+This role configures the gcsfuse repository, and installs gcsfuse on your host.
+gcsfuse is a user-space file system for working with
+[Google Cloud Storage](https://cloud.google.com/storage/).
+
+**Important:** You should run gcsfuse as the user who will be using the file
+system, not as the root user. Do not use sudo either.
+
+After installed you can use it to mount by command:
+`gcsfuse bucket-name /mount/point`
+
+## Example Playbook
+
+Including an example of how to use your role (for instance, with variables
+passed in as parameters) is always nice for users too:
+
+```yaml
+- hosts: servers
+  tasks:
+    - include_role:
+        name: google.cloud.gcsfuse
+```
+
+## License
+
+GPLv3
+
+## Author Information
+
+[ericsysmin](https://ericsysmin.com)

--- a/roles/gcsfuse/defaults/main.yml
+++ b/roles/gcsfuse/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for google.cloud.gcsfuse

--- a/roles/gcsfuse/handlers/main.yml
+++ b/roles/gcsfuse/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for google.cloud.gcsfuse

--- a/roles/gcsfuse/tasks/debian.yml
+++ b/roles/gcsfuse/tasks/debian.yml
@@ -1,0 +1,25 @@
+---
+- name: gcsfuse | Ensure gpg is installed
+  apt: name=gnupg
+  register: task_result
+  until: task_result is success
+  retries: 10
+  delay: 2
+
+- name: gcsfuse | Add an apt signing key
+  apt_key:
+    url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
+    state: present
+
+- name: gcsfuse | Add the apt repository
+  apt_repository:
+    repo: deb http://packages.cloud.google.com/apt gcsfuse-{{ ansible_distribution_release }} main
+    state: present
+    filename: gcsfuse
+
+- name: gcsfuse | Install gcsfuse
+  apt: name=gcsfuse update_cache=yes
+  register: task_result
+  until: task_result is success
+  retries: 10
+  delay: 2

--- a/roles/gcsfuse/tasks/main.yml
+++ b/roles/gcsfuse/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+# tasks file for google.cloud.gcsfuse
+
+- include_tasks: "{{ ansible_os_family|lower }}.yml"

--- a/roles/gcsfuse/vars/main.yml
+++ b/roles/gcsfuse/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for google.cloud.gcsfuse


### PR DESCRIPTION
##### SUMMARY
Adding role for gcsfuse as described here https://github.com/GoogleCloudPlatform/gcsfuse

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
google.cloud.gcsfuse

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
- hosts: servers
  tasks:
    - include_role:
        name: google.cloud.gcsfuse
```
