### PR TITLE
Stackdriver Logging role for GCP

### DIFF
--- a/roles/stackdriver_logging/README.md
+++ b/roles/stackdriver_logging/README.md
@@ -1,0 +1,59 @@
+# stackdriver_logging
+
+Ansible role to install the Stackdriver Logging Agent.
+
+## Requirements
+
+Permissions to Google Cloud API. If running on an old Compute Engine instance or
+Compute Engine instances created without the default credentials, then you must
+complete the following steps
+<https://cloud.google.com/logging/docs/agent/authorization#before_you_begin>
+
+## Role Variables
+
+| Variable                       | Default                        | Comments                                           |
+| ------------------------------ | ------------------------------ | -------------------------------------------------- |
+| `stackdriver_log_service_name` | Please see `defaults/main.yml` | Stackdriver service name                           |
+| `stackdriver_log_package_name` | Please see `defaults/main.yml` | Package name of the Stackdriver agent              |
+| `stackdriver_log_repo_host`    | Please see `defaults/main.yml` | Hostname of the repository the package is loacated |
+| `stackdriver_log_repo_suffix`  | Please see `defaults/main.yml` | Sufffix for the repository ex. `all`               |
+| `stackdriver_http_proxy`       | Undefined                      | HTTP Proxy for Stackdriver                         |
+| `stackdriver_https_proxy`      | Undefined                      | HTTPS Proxy for Stackdriver                        |
+| `stackdriver_no_proxy`         | Undefined                      | Skip proxy for the local Metadata Server.          |
+
+### Debian Specific
+
+| Variable                        | Required                       | Comments                                             |
+| ------------------------------- | ------------------------------ | ---------------------------------------------------- |
+| `stackdriver_log_apt_repo_url`  | Please see `defaults/main.yml` | APT repository url                                   |
+| `stackdriver_log_apt_gpg_key`   | Please see `defaults/main.yml` | GPG Key for verifying the APT repository.            |
+| `stackdriver_log_apt_repo_name` | Please see `defaults/main.yml` | Skips any requirements for disk space, ram, and cpu. |
+
+### RedHat Specific
+
+| Variable                        | Required                       | Comments                                             |
+| ------------------------------- | ------------------------------ | ---------------------------------------------------- |
+| `stackdriver_log_yum_repo_url`  | Please see `defaults/main.yml` | Skips any requirements for disk space, ram, and cpu. |
+| `stackdriver_log_yum_repo_name` | Please see `defaults/main.yml` | Skips any requirements for disk space, ram, and cpu. |
+| `stackdriver_log_yum_repo`      | Please see `defaults/main.yml` | Skips any requirements for disk space, ram, and cpu. |
+| `stackdriver_log_yum_gpg_key`   | Please see `defaults/main.yml` | Skips any requirements for disk space, ram, and cpu. |
+| `stackdriver_log_service_name`  | Please see `defaults/main.yml` | Skips any requirements for disk space, ram, and cpu. |
+
+## Dependencies
+
+## Example Playbook
+
+```yaml
+- hosts: localhost
+  become: yes
+  roles:
+    - role: google.cloud.stackdriver_logging
+```
+
+## License
+
+GPLv3
+
+## Author Information
+
+[Eric Anderson](https://ericsysmin.com)

--- a/roles/stackdriver_logging/defaults/main.yml
+++ b/roles/stackdriver_logging/defaults/main.yml
@@ -1,0 +1,26 @@
+---
+# defaults file for stackdriver_logging
+
+stackdriver_log_service_name: google-fluentd
+stackdriver_log_package_name: google-fluentd
+stackdriver_log_config_type: unstructured
+stackdriver_log_config_name: "{{ 'google-fluentd-catch-all-config' if stackdriver_log_config_type == 'unstructured' \
+  else 'google-fluentd-catch-all-config-structured' }}"
+stackdriver_log_catch_all_conf: true
+stackdriver_log_repo_host: packages.cloud.google.com
+stackdriver_log_repo_suffix_value: "{{ '-' ~ stackdriver_log_repo_suffix if stackdriver_log_repo_suffix is defined else '' }}"
+
+# debian package
+stackdriver_log_apt_repo_url: https://{{ stackdriver_log_repo_host }}/apt
+stackdriver_log_apt_gpg_key: "{{ stackdriver_log_apt_repo_url }}/doc/apt-key.gpg"
+stackdriver_log_apt_repo_name: >-
+  google-cloud-logging-wheezy{{ stackdriver_log_repo_suffix_value }}
+
+# yum package
+stackdriver_log_yum_repo_url: https://{{ stackdriver_log_repo_host }}/yum
+stackdriver_log_yum_repo_name: >-
+  google-cloud-monitoring-el{{ ansible_distribution_major_version }}-{{ ansible_architecture }}{{ stackdriver_log_repo_suffix_value }}
+stackdriver_log_yum_repo: "{{ stackdriver_log_yum_repo_url }}/repos/{{ stackdriver_log_yum_repo_name }}"
+stackdriver_log_yum_gpg_key:
+  - "{{ stackdriver_log_yum_repo_url }}/doc/yum-key.gpg"
+  - "{{ stackdriver_log_yum_repo_url }}/doc/rpm-package-key.gpg"

--- a/roles/stackdriver_logging/handlers/main.yml
+++ b/roles/stackdriver_logging/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+# handlers file for stackdriver_logging
+
+- name: Stackdriver Logging | Restart Stackdriver Agent
+  service: name={{ stackdriver_log_service_name }} state=restarted

--- a/roles/stackdriver_logging/meta/main.yml
+++ b/roles/stackdriver_logging/meta/main.yml
@@ -1,0 +1,20 @@
+---
+galaxy_info:
+  author: ericsysmin
+  role_name: stackdriver_logging
+  description: Ansible role to install Stackdriver logging agent
+  license: Apache-2.0
+  min_ansible_version: 2.8
+  platforms:
+    - name: EL
+      versions:
+        - 6
+        - 7
+        - 8
+    - name: Ubuntu
+      versions:
+        - precise
+        - trusty
+        - xenial
+  galaxy_tags: []
+dependencies: []

--- a/roles/stackdriver_logging/molecule/default/.ansible-lint
+++ b/roles/stackdriver_logging/molecule/default/.ansible-lint
@@ -1,0 +1,6 @@
+---
+parseable: true
+skip_list:
+  - ANSIBLE0010
+use_default_rules: true
+verbosity: 1

--- a/roles/stackdriver_logging/molecule/default/.yamllint
+++ b/roles/stackdriver_logging/molecule/default/.yamllint
@@ -1,0 +1,11 @@
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  line-length: disable
+  truthy: disable

--- a/roles/stackdriver_logging/molecule/default/Dockerfile.j2
+++ b/roles/stackdriver_logging/molecule/default/Dockerfile.j2
@@ -1,0 +1,22 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+{% if item.env is defined %}
+{% for var, value in item.env.items() %}
+{% if value %}
+ENV {{ var }} {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash iproute && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash iproute && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml iproute2 && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates iproute2 && xbps-remove -O; fi

--- a/roles/stackdriver_logging/molecule/default/molecule.yml
+++ b/roles/stackdriver_logging/molecule/default/molecule.yml
@@ -1,0 +1,27 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+  options:
+    config-file: molecule/default/.yamllint
+platforms:
+  - name: instance
+    image: ${MOLECULE_DISTRO}
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+    options:
+      c: molecule/default/.ansible-lint
+scenario:
+  name: default
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/roles/stackdriver_logging/molecule/default/playbook.yml
+++ b/roles/stackdriver_logging/molecule/default/playbook.yml
@@ -1,0 +1,5 @@
+---
+- name: Converge
+  hosts: all
+  roles:
+    - role: stackdriver_logging

--- a/roles/stackdriver_logging/molecule/default/tests/test_default.py
+++ b/roles/stackdriver_logging/molecule/default/tests/test_default.py
@@ -1,0 +1,15 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_hosts_file(host):
+    f = host.file('/etc/hosts')
+
+    assert f.exists
+    assert f.user == 'root'
+    assert f.group == 'root'

--- a/roles/stackdriver_logging/tasks/debian.yml
+++ b/roles/stackdriver_logging/tasks/debian.yml
@@ -1,0 +1,25 @@
+---
+- name: Stackdriver Logging | Debian | Add the Stackdriver repository
+  apt_repository:
+    repo: "deb {{ stackdriver_log_apt_repo_url }} {{ stackdriver_log_apt_repo_name }} main"
+    filename: google-cloud-logging
+    state: present
+
+- name: Stackdriver Logging | Debian | Ensure Stackdriver's GPG key is available.
+  apt_key:
+    url: "{{ stackdriver_log_apt_repo_url }}/doc/apt-key.gpg"
+    state: present
+
+- name: Stackdriver Logging | Debian | Install the Stackdriver agent
+  apt:
+    name: "{{ stackdriver_log_package_name }}"
+    state: present
+    update_cache: yes
+  notify: Stackdriver Logging | Restart Stackdriver Agent
+
+- name: Stackdriver Logging | Debian | Install the Stackdriver catch all config
+  apt:
+    name: "{{ stackdriver_log_config_name }}"
+    state: present
+    update_cache: yes
+  when: stackdriver_log_catch_all_conf

--- a/roles/stackdriver_logging/tasks/main.yml
+++ b/roles/stackdriver_logging/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+# tasks file for stackdriver_logging
+
+- name: Stackdriver Logging | OS Based Installation
+  include_tasks: "{{ ansible_os_family|lower }}.yml"
+
+- name: Stackdriver Logging | Install the Stackdriver defaults file
+  template:
+    src: default/google-fluentd
+    dest: /etc/default/google-fluentd
+  when: stackdriver_http_proxy is defined or
+        stackdriver_https_proxy is defined
+
+- name: Stackdriver Logging | Install the logging files
+  template:
+    src: source.conf
+    dest: /etc/google-fluentd/config.d/{{ item.name }}.conf
+  loop: "{{ stackdriver_log_files }}"
+  when: stackdriver_log_files is defined
+  notify: Stackdriver Logging | Restart Stackdriver Agent

--- a/roles/stackdriver_logging/tasks/redhat.yml
+++ b/roles/stackdriver_logging/tasks/redhat.yml
@@ -1,0 +1,20 @@
+---
+- name: Stackdriver Logging | RedHat | Install the Python bindings for SELinux
+  yum: name=libselinux-python state=present
+
+- name: Stackdriver Logging | RedHat | Add the Stackdriver repository
+  yum_repository:
+    name: google-cloud-logging
+    description: Google Cloud Logging Agent Repository
+    baseurl: "{{ stackdriver_log_yum_repo }}"
+    file: google-cloud-logging
+    enabled: yes
+    gpgcheck: yes
+    repo_gpgcheck: yes
+    gpgkey: "{{ stackdriver_log_yum_gpg_key }}"
+
+- name: Stackdriver Logging | RedHat | Install Stackdriver agent
+  yum:
+    name: "{{ stackdriver_log_package_name }}"
+    state: present
+  notify: Stackdriver Logging | Restart Stackdriver Agent

--- a/roles/stackdriver_logging/templates/default/google-fluentd
+++ b/roles/stackdriver_logging/templates/default/google-fluentd
@@ -1,0 +1,8 @@
+# {{ ansible_managed }}
+{% if stackdriver_http_proxy is defined %}
+export http_proxy="{{ stackdriver_http_proxy }}"
+{% endif %}
+{% if stackdriver_https_proxy is defined %}
+export https_proxy="{{ stackdriver_https_proxy }}"
+{% endif %}
+export no_proxy==169.254.169.254

--- a/roles/stackdriver_logging/templates/source.conf
+++ b/roles/stackdriver_logging/templates/source.conf
@@ -1,0 +1,11 @@
+# {{ ansible_managed }}
+{% for source in item.sources %}
+<source>
+  @type tail
+  format {{ source.format }}
+  path {{ source.path }}
+  pos_file {{ source.pos_file }}
+  read_from_head {{ source.read_from_head|string|lower }}
+  tag {{ source.tag }}
+</source>
+{% endfor %}

--- a/roles/stackdriver_logging/vars/main.yml
+++ b/roles/stackdriver_logging/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for stackdriver_logging


### PR DESCRIPTION
##### SUMMARY
This provides the role for installing and configuring the Stackdriver Logging agent located here https://cloud.google.com/logging/docs/agent

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
google.cloud.stackdriver_logging

##### ADDITIONAL INFORMATION

```yaml
- hosts: localhost
  become: yes
  tasks:
    - include_role:
        name: google.cloud.stackdriver_logging
```
