### PR TITLE
Stackdriver Monitoring role for GCP Stackdriver

### DIFF
--- a/roles/stackdriver_monitoring/README.md
+++ b/roles/stackdriver_monitoring/README.md
@@ -1,0 +1,60 @@
+# stackdriver_monitoring
+
+Ansible role to install the Stackdriver Logging Agent.
+
+## Requirements
+
+Permissions to Google Cloud API. If running on an old Compute Engine instance or
+Compute Engine instances created without the default credentials, then you must
+complete the following steps
+<https://cloud.google.com/monitoring/agent/authorization#before_you_begin>
+
+## Role Variables
+
+| Variable                       | Default                        | Comments                                           |
+| ------------------------------ | ------------------------------ | -------------------------------------------------- |
+| `stackdriver_mon_service_name` | Please see `defaults/main.yml` | Stackdriver service name                           |
+| `stackdriver_mon_package_name` | Please see `defaults/main.yml` | Package name of the Stackdriver agent              |
+| `stackdriver_mon_repo_host`    | Please see `defaults/main.yml` | Hostname of the repository the package is loacated |
+| `stackdriver_mon_repo_suffix`  | Please see `defaults/main.yml` | Sufffix for the repository ex. `all`               |
+| `stackdriver_http_proxy`       | Undefined                      | HTTP Proxy for Stackdriver                         |
+| `stackdriver_https_proxy`      | Undefined                      | HTTPS Proxy for Stackdriver                        |
+| `stackdriver_no_proxy`         | Undefined                      | Skip proxy for the local Metadata Server.          |
+
+### Debian Specific
+
+| Variable                        | Required                       | Comments                                             |
+| ------------------------------- | ------------------------------ | ---------------------------------------------------- |
+| `stackdriver_mon_apt_repo_url`  | Please see `defaults/main.yml` | APT repository url                                   |
+| `stackdriver_mon_apt_gpg_key`   | Please see `defaults/main.yml` | GPG Key for verifying the APT repository.            |
+| `stackdriver_mon_apt_repo_name` | Please see `defaults/main.yml` | Skips any requirements for disk space, ram, and cpu. |
+
+### RedHat Specific
+
+| Variable                        | Required                       | Comments                                             |
+| ------------------------------- | ------------------------------ | ---------------------------------------------------- |
+| `stackdriver_mon_yum_repo_url`  | Please see `defaults/main.yml` | Skips any requirements for disk space, ram, and cpu. |
+| `stackdriver_mon_yum_repo_name` | Please see `defaults/main.yml` | Skips any requirements for disk space, ram, and cpu. |
+| `stackdriver_mon_yum_repo`      | Please see `defaults/main.yml` | Skips any requirements for disk space, ram, and cpu. |
+| `stackdriver_mon_yum_gpg_key`   | Please see `defaults/main.yml` | Skips any requirements for disk space, ram, and cpu. |
+| `stackdriver_mon_service_name`  | Please see `defaults/main.yml` | Skips any requirements for disk space, ram, and cpu. |
+
+## Dependencies
+
+## Example Playbook
+
+```yaml
+- hosts: localhost
+  become: yes
+  tasks:
+    - include_role:
+        name: google.cloud.stackdriver_monitoring
+```
+
+## License
+
+GPLv3
+
+## Author Information
+
+[Eric Anderson](https://ericsysmin.com)

--- a/roles/stackdriver_monitoring/defaults/main.yml
+++ b/roles/stackdriver_monitoring/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+# defaults file for stackdriver_monitoring
+
+stackdriver_mon_service_name: stackdriver-agent
+stackdriver_mon_package_name: stackdriver-agent
+stackdriver_mon_repo_host: packages.cloud.google.com
+stackdriver_mon_repo_suffix: all
+
+# debian package
+stackdriver_mon_apt_repo_url: https://{{ stackdriver_mon_repo_host }}/apt
+stackdriver_mon_apt_gpg_key: "{{ stackdriver_mon_apt_repo_url }}/doc/apt-key.gpg"
+stackdriver_mon_apt_repo_name: google-cloud-monitoring-{{ ansible_lsb.codename }}-{{ stackdriver_mon_repo_suffix }}
+
+# yum package
+stackdriver_mon_yum_repo_url: https://{{ stackdriver_mon_repo_host }}/yum
+stackdriver_mon_yum_repo_name: google-cloud-monitoring-el{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-{{ stackdriver_mon_repo_suffix }}
+stackdriver_mon_yum_repo: "{{ stackdriver_mon_yum_repo_url }}/repos/{{ stackdriver_mon_yum_repo_name }}"
+stackdriver_mon_yum_gpg_key:
+  - "{{ stackdriver_mon_yum_repo_url }}/doc/yum-key.gpg"
+  - "{{ stackdriver_mon_yum_repo_url }}/doc/rpm-package-key.gpg"

--- a/roles/stackdriver_monitoring/handlers/main.yml
+++ b/roles/stackdriver_monitoring/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+# handlers file for stackdriver_monitoring
+
+- name: Stackdriver Monitoring | Restart Stackdriver Agent
+  service: name={{ stackdriver_mon_service_name }} state=restarted

--- a/roles/stackdriver_monitoring/meta/main.yml
+++ b/roles/stackdriver_monitoring/meta/main.yml
@@ -1,0 +1,20 @@
+---
+galaxy_info:
+  author: ericsysmin
+  role_name: stackdriver_monitoring
+  description: Ansible role to install Stackdriver monitoring agent
+  license: Apache-2.0
+  min_ansible_version: 2.8
+  platforms:
+    - name: EL
+      versions:
+        - 6
+        - 7
+        - 8
+    - name: Ubuntu
+      versions:
+        - precise
+        - trusty
+        - xenial
+  galaxy_tags: []
+dependencies: []

--- a/roles/stackdriver_monitoring/molecule/default/.ansible-lint
+++ b/roles/stackdriver_monitoring/molecule/default/.ansible-lint
@@ -1,0 +1,6 @@
+---
+parseable: true
+skip_list:
+  - ANSIBLE0010
+use_default_rules: true
+verbosity: 1

--- a/roles/stackdriver_monitoring/molecule/default/.yamllint
+++ b/roles/stackdriver_monitoring/molecule/default/.yamllint
@@ -1,0 +1,11 @@
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  line-length: disable
+  truthy: disable

--- a/roles/stackdriver_monitoring/molecule/default/Dockerfile.j2
+++ b/roles/stackdriver_monitoring/molecule/default/Dockerfile.j2
@@ -1,0 +1,22 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+{% if item.env is defined %}
+{% for var, value in item.env.items() %}
+{% if value %}
+ENV {{ var }} {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash iproute && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash iproute && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml iproute2 && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates iproute2 && xbps-remove -O; fi

--- a/roles/stackdriver_monitoring/molecule/default/molecule.yml
+++ b/roles/stackdriver_monitoring/molecule/default/molecule.yml
@@ -1,0 +1,27 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+  options:
+    config-file: molecule/default/.yamllint
+platforms:
+  - name: instance
+    image: ${MOLECULE_DISTRO}
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+    options:
+      c: molecule/default/.ansible-lint
+scenario:
+  name: default
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/roles/stackdriver_monitoring/molecule/default/playbook.yml
+++ b/roles/stackdriver_monitoring/molecule/default/playbook.yml
@@ -1,0 +1,5 @@
+---
+- name: Converge
+  hosts: all
+  roles:
+    - role: stackdriver_monitoring

--- a/roles/stackdriver_monitoring/molecule/default/tests/test_default.py
+++ b/roles/stackdriver_monitoring/molecule/default/tests/test_default.py
@@ -1,0 +1,15 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_hosts_file(host):
+    f = host.file('/etc/hosts')
+
+    assert f.exists
+    assert f.user == 'root'
+    assert f.group == 'root'

--- a/roles/stackdriver_monitoring/tasks/debian.yml
+++ b/roles/stackdriver_monitoring/tasks/debian.yml
@@ -1,0 +1,18 @@
+---
+- name: Stackdriver Monitoring | Debian | Add the Stackdriver repository
+  apt_repository:
+    repo: "deb {{ stackdriver_mon_apt_repo_url }} {{ stackdriver_mon_apt_repo_name }} main"
+    filename: google-cloud-monitoring
+    state: present
+
+- name: Stackdriver Monitoring | Debian | Ensure Stackdriver's GPG key is available.
+  apt_key:
+    url: "{{ stackdriver_mon_apt_repo_url }}/doc/apt-key.gpg"
+    state: present
+
+- name: Stackdriver Monitoring | Debian | Install the Stackdriver agent
+  apt:
+    name: "{{ stackdriver_mon_package_name }}"
+    state: present
+    update_cache: yes
+  notify: Stackdriver Monitoring | Restart Stackdriver Agent

--- a/roles/stackdriver_monitoring/tasks/main.yml
+++ b/roles/stackdriver_monitoring/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# tasks file for stackdriver_monitoring
+
+- name: Stackdriver Monitoring | OS Based Installation
+  include_tasks: "{{ ansible_os_family|lower }}.yml"

--- a/roles/stackdriver_monitoring/tasks/redhat.yml
+++ b/roles/stackdriver_monitoring/tasks/redhat.yml
@@ -1,0 +1,21 @@
+---
+- name: Stackdriver Monitoring | RedHat | Install the Python bindings for SELinux
+  yum: name=libselinux-python state=present
+
+- name: Stackdriver Monitoring | RedHat | Add the Stackdriver repository
+  yum_repository:
+    name: google-cloud-monitoring
+    description: Google Cloud Monitoring Agent Repository
+    baseurl: "{{ stackdriver_mon_yum_repo }}"
+    file: google-cloud-monitoring
+    enabled: yes
+    gpgcheck: yes
+    repo_gpgcheck: yes
+    gpgkey: "{{ stackdriver_mon_yum_gpg_key }}"
+
+
+- name: Stackdriver Monitoring | RedHat | Install Stackdriver agent
+  yum:
+    name: "{{ stackdriver_mon_package_name }}"
+    state: present
+  notify: Stackdriver Monitoring | Restart Stackdriver Agent

--- a/roles/stackdriver_monitoring/templates/default/stackdriver-agent
+++ b/roles/stackdriver_monitoring/templates/default/stackdriver-agent
@@ -1,0 +1,9 @@
+{% if stackdriver_http_proxy is defined %}
+export http_proxy="{{ stackdriver_http_proxy }}"
+{% endif %}
+{% if stackdriver_https_proxy is defined %}
+export https_proxy="{{ stackdriver_https_proxy }}"
+{% endif %}
+{% if stackdriver_no_proxy %}
+export no_proxy==169.254.169.254
+{% endif %}

--- a/roles/stackdriver_monitoring/vars/main.yml
+++ b/roles/stackdriver_monitoring/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for stackdriver_monitoring


### PR DESCRIPTION
##### SUMMARY
Provide a role for GCP Stackdriver Monitoring based on https://cloud.google.com/monitoring/agent/install-agent

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
google.cloud.stackdriver_monitoring

##### ADDITIONAL INFORMATION
```yaml
- hosts: localhost
  become: yes
  tasks:
    - include_role:
        name: google.cloud.stackdriver_monitoring
```
