### PR TITLE
Change imports to work inside collection

### DIFF
--- a/plugins/inventory/gcp_compute.py
+++ b/plugins/inventory/gcp_compute.py
@@ -145,7 +145,7 @@ import json
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import missing_required_lib
-from ansible.module_utils.gcp_utils import (
+from ..module_utils.gcp_utils import (
     GcpSession,
     navigate_hash,
     GcpRequestException,


### PR DESCRIPTION
##### SUMMARY
Without this, the inventory plugin is failing with Ansible `devel` branch (ansible-base) with

```
[WARNING]:  * Failed to parse /tmp/awx_136_z4baj3i4/gcp_compute.yml with auto
plugin: No module named gcp_utils
  File "/usr/lib/python2.7/site-packages/ansible/inventory/manager.py", line 287, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/usr/lib/python2.7/site-packages/ansible/plugins/inventory/auto.py", line 50, in parse
    plugin = inventory_loader.get(plugin_name)
  File "/usr/lib/python2.7/site-packages/ansible/plugins/loader.py", line 552, in get
    self._module_cache[path] = self._load_module_source(name, path)
  File "/usr/lib/python2.7/site-packages/ansible/plugins/loader.py", line 530, in _load_module_source
    module = imp.load_source(to_native(full_name), to_native(path), module_file)
  File "/var/lib/awx/vendor/inventory_collections/ansible_collections/google/cloud/plugins/inventory/gcp_compute.py", line 148, in <module>
    from ansible.module_utils.gcp_utils import (
```

so it was importing the module utils from before the break into a collection.

Luckily, those same names exist in the current collection's module utils!

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/inventory

##### ADDITIONAL INFORMATION
Tested and confirmed that this restores _basic_ functionality. Meaning that I did an `ansible-inventory` call and confirmed that I'm getting the traceback reported here, and then that making this patch returns content again (that I have no reason to believe differs from Ansible 2.9 behavior).