### PR TITLE
Add custom hostname set in GCE to the hostnames block of the inventory plugin

### DIFF
--- a/plugins/inventory/gcp_compute.py
+++ b/plugins/inventory/gcp_compute.py
@@ -237,7 +237,11 @@ class GcpInstance(object):
             elif order == "name":
                 name = self.json[u"name"]
             elif order == "metadata_hostname":
-                name = self.json[u"hostname"]
+                if "hostname" in self.json:
+                    name = self.json[u"hostname"]
+                else:
+                    name = self.json[u"name"]
+
             else:
                 raise AnsibleParserError("%s is not a valid hostname precedent" % order)
 

--- a/plugins/inventory/gcp_compute.py
+++ b/plugins/inventory/gcp_compute.py
@@ -236,6 +236,8 @@ class GcpInstance(object):
                 name = self._get_privateip()
             elif order == "name":
                 name = self.json[u"name"]
+            elif order == "metadata_hostname":
+                name = self.json[u"hostname"]
             else:
                 raise AnsibleParserError("%s is not a valid hostname precedent" % order)
 

--- a/plugins/inventory/gcp_compute.py
+++ b/plugins/inventory/gcp_compute.py
@@ -45,8 +45,12 @@ DOCUMENTATION = """
         hostnames:
           description: A list of options that describe the ordering for which
               hostnames should be assigned. Currently supported hostnames are
-              'public_ip', 'private_ip', or 'name'.
-          default: ['public_ip', 'private_ip', 'name']
+              'public_ip', 'private_ip', 'name', or 'custom_hostname'.
+              'name' is the instance name in GCE.
+              'custom_hostname' is the custom hostname set when creating the
+              instance. Falls back to 'name' if a custom hostname is not
+              defined.
+          default: ['public_ip', 'private_ip', 'name', 'custom_hostname']
           type: list
         auth_kind:
             description:
@@ -236,7 +240,7 @@ class GcpInstance(object):
                 name = self._get_privateip()
             elif order == "name":
                 name = self.json[u"name"]
-            elif order == "metadata_hostname":
+            elif order == "custom_hostname":
                 if "hostname" in self.json:
                     name = self.json[u"hostname"]
                 else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change allows the use of the custom hostname set when creating an instance in GCE as the `inventory_hostname` in playbooks. Includes a fallback to the instance name in the case that a custom hostname is not defined. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`gcp_compute.py` (dynamic inventory plugin)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The `hostname` block already allowed the dynamic inventory plugin to use the instance name, but I am setting a custom hostname for my instances (via `terraform`) and wanted to be able to leverage that in `ansible`. I added a few lines of code that allowed this, with a fallback in case some instances do not have a custom hostname set. 
<!--- Paste verbatim command output below, e.g. before and after your change -->