### PR TITLE
Added in link to where machineTypes are defined

### DIFF
--- a/plugins/modules/gcp_compute_instance.py
+++ b/plugins/modules/gcp_compute_instance.py
@@ -823,7 +823,8 @@ metadata:
   type: dict
 machineType:
   description:
-  - A reference to a machine type which defines VM kind.
+  - A reference to a machine type which defines VM kind. See https://cloud.google.com/compute/docs/machine-types
+    for a list of current valid machine types.
   returned: success
   type: str
 minCpuPlatform:


### PR DESCRIPTION
##### SUMMARY
Nothing major, just a link off to the google cloud site (https://cloud.google.com/compute/docs/machine-types) that has the valid machine types required for gcp_compute_instance machineType field. Make it a bit easier when perusing the docs to figure out what exactly is supposed to go in there.

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
gcp_compute_instance

