### PR TITLE
Add new parameter 'range' for google sheets options

### DIFF
--- a/plugins/modules/gcp_bigquery_table.py
+++ b/plugins/modules/gcp_bigquery_table.py
@@ -113,6 +113,11 @@ options:
     required: false
     type: dict
     suboptions:
+      query:
+        description:
+        - A query that BigQuery executes when the view is referenced.
+        required: true
+        type: str
       use_legacy_sql:
         description:
         - Specifies whether to use BigQuery's legacy SQL for this view .
@@ -641,6 +646,11 @@ view:
   returned: success
   type: complex
   contains:
+    query:
+      description:
+      - A query that BigQuery executes when the view is referenced.
+      required: true
+      type: str
     useLegacySql:
       description:
       - Specifies whether to use BigQuery's legacy SQL for this view .
@@ -1027,6 +1037,7 @@ def main():
             view=dict(
                 type='dict',
                 options=dict(
+                    query=dict(required=True, type='str'),
                     use_legacy_sql=dict(type='bool'),
                     user_defined_function_resources=dict(
                         type='list', elements='dict', options=dict(inline_code=dict(type='str'), resource_uri=dict(type='str'))
@@ -1311,6 +1322,7 @@ class TableView(object):
     def to_request(self):
         return remove_nones_from_dict(
             {
+                u'query': self.request.get('query'),
                 u'useLegacySql': self.request.get('use_legacy_sql'),
                 u'userDefinedFunctionResources': TableUserdefinedfunctionresourcesArray(
                     self.request.get('user_defined_function_resources', []), self.module
@@ -1321,6 +1333,7 @@ class TableView(object):
     def from_response(self):
         return remove_nones_from_dict(
             {
+                u'query': self.request.get(u'query'),
                 u'useLegacySql': self.request.get(u'useLegacySql'),
                 u'userDefinedFunctionResources': TableUserdefinedfunctionresourcesArray(
                     self.request.get(u'userDefinedFunctionResources', []), self.module

--- a/plugins/modules/gcp_bigquery_table.py
+++ b/plugins/modules/gcp_bigquery_table.py
@@ -332,6 +332,11 @@ options:
               when reading the data.
             required: false
             type: int
+          range:
+            description:
+            - Range of a sheet to query from. Only used when non-empty.
+            required: true
+            type: str
       csv_options:
         description:
         - Additional properties to set if sourceFormat is set to CSV.
@@ -1072,7 +1077,13 @@ def main():
                             )
                         ),
                     ),
-                    google_sheets_options=dict(type='dict', options=dict(skip_leading_rows=dict(default=0, type='int'))),
+                    google_sheets_options=dict(
+                        type='dict', 
+                        options=dict(
+                            skip_leading_rows=dict(default=0, type='int')
+                            range=dict(type='str')
+                        )
+                    ),
                     csv_options=dict(
                         type='dict',
                         options=dict(
@@ -1560,10 +1571,20 @@ class TableGooglesheetsoptions(object):
             self.request = {}
 
     def to_request(self):
-        return remove_nones_from_dict({u'skipLeadingRows': self.request.get('skip_leading_rows')})
+        return remove_nones_from_dict(
+            {
+                u'skipLeadingRows': self.request.get('skip_leading_rows'),
+                u'range': self.request.get('range'),
+            }
+        )
 
     def from_response(self):
-        return remove_nones_from_dict({u'skipLeadingRows': self.request.get(u'skipLeadingRows')})
+        return remove_nones_from_dict(
+            {
+                u'skipLeadingRows': self.request.get(u'skipLeadingRows'),
+                u'range': self.request.get(u'range'),
+            }
+        )
 
 
 class TableCsvoptions(object):

--- a/plugins/modules/gcp_bigquery_table.py
+++ b/plugins/modules/gcp_bigquery_table.py
@@ -335,7 +335,7 @@ options:
           range:
             description:
             - Range of a sheet to query from. Only used when non-empty.
-            required: true
+            required: false
             type: str
       csv_options:
         description:

--- a/plugins/modules/gcp_bigquery_table_info.py
+++ b/plugins/modules/gcp_bigquery_table_info.py
@@ -214,6 +214,11 @@ resources:
       returned: success
       type: complex
       contains:
+        query:
+          description:
+          - A query that BigQuery executes when the view is referenced.
+          required: true
+          type: str
         useLegacySql:
           description:
           - Specifies whether to use BigQuery's legacy SQL for this view .
@@ -444,6 +449,11 @@ resources:
                 skip when reading the data.
               returned: success
               type: int
+            range:
+              description:
+              - Range of a sheet to query from. Only used when non-empty.
+              required: false
+              type: str
         csvOptions:
           description:
           - Additional properties to set if sourceFormat is set to CSV.


### PR DESCRIPTION
##### SUMMARY
This change will help to use a new parameter "range" for tables with an external source as Google SpreadSheets.
https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#GoogleSheetsOptions - here you can see a new parameter.

Additional parameter "query" for view section.
https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#ViewDefinition - here you can see a new parameter

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
gcp_bigquery_table
gcp_bigquery_table_info

##### ADDITIONAL INFORMATION
```paste below

```
