### PR TITLE
Move imports from Ansible to this collection

### DIFF
--- a/plugins/modules/gcp_appengine_firewall_rule_info.py
+++ b/plugins/modules/gcp_appengine_firewall_rule_info.py
@@ -134,7 +134,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_bigquery_dataset_info.py
+++ b/plugins/modules/gcp_bigquery_dataset_info.py
@@ -298,7 +298,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_bigquery_table_info.py
+++ b/plugins/modules/gcp_bigquery_table_info.py
@@ -574,7 +574,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_bigtable_instance_info.py
+++ b/plugins/modules/gcp_bigtable_instance_info.py
@@ -172,7 +172,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_cloudbuild_trigger_info.py
+++ b/plugins/modules/gcp_cloudbuild_trigger_info.py
@@ -376,7 +376,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_cloudfunctions_cloud_function_info.py
+++ b/plugins/modules/gcp_cloudfunctions_cloud_function_info.py
@@ -257,7 +257,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_cloudscheduler_job_info.py
+++ b/plugins/modules/gcp_cloudscheduler_job_info.py
@@ -358,7 +358,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_cloudtasks_queue_info.py
+++ b/plugins/modules/gcp_cloudtasks_queue_info.py
@@ -250,7 +250,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_address_info.py
+++ b/plugins/modules/gcp_compute_address_info.py
@@ -201,7 +201,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_autoscaler_info.py
+++ b/plugins/modules/gcp_compute_autoscaler_info.py
@@ -261,7 +261,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_backend_bucket_info.py
+++ b/plugins/modules/gcp_compute_backend_bucket_info.py
@@ -170,7 +170,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_backend_service_info.py
+++ b/plugins/modules/gcp_compute_backend_service_info.py
@@ -679,7 +679,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_disk_info.py
+++ b/plugins/modules/gcp_compute_disk_info.py
@@ -332,7 +332,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_external_vpn_gateway_info.py
+++ b/plugins/modules/gcp_compute_external_vpn_gateway_info.py
@@ -158,7 +158,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_firewall_info.py
+++ b/plugins/modules/gcp_compute_firewall_info.py
@@ -299,7 +299,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_forwarding_rule_info.py
+++ b/plugins/modules/gcp_compute_forwarding_rule_info.py
@@ -288,7 +288,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_global_address_info.py
+++ b/plugins/modules/gcp_compute_global_address_info.py
@@ -186,7 +186,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_global_forwarding_rule_info.py
+++ b/plugins/modules/gcp_compute_global_forwarding_rule_info.py
@@ -265,7 +265,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_health_check_info.py
+++ b/plugins/modules/gcp_compute_health_check_info.py
@@ -455,7 +455,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_http_health_check_info.py
+++ b/plugins/modules/gcp_compute_http_health_check_info.py
@@ -187,7 +187,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_https_health_check_info.py
+++ b/plugins/modules/gcp_compute_https_health_check_info.py
@@ -187,7 +187,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_image_info.py
+++ b/plugins/modules/gcp_compute_image_info.py
@@ -318,7 +318,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_instance_group_info.py
+++ b/plugins/modules/gcp_compute_instance_group_info.py
@@ -196,7 +196,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_instance_group_manager_info.py
+++ b/plugins/modules/gcp_compute_instance_group_manager_info.py
@@ -271,7 +271,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_instance_info.py
+++ b/plugins/modules/gcp_compute_instance_info.py
@@ -580,7 +580,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_instance_template_info.py
+++ b/plugins/modules/gcp_compute_instance_template_info.py
@@ -543,7 +543,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_interconnect_attachment_info.py
+++ b/plugins/modules/gcp_compute_interconnect_attachment_info.py
@@ -267,7 +267,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_network_endpoint_group_info.py
+++ b/plugins/modules/gcp_compute_network_endpoint_group_info.py
@@ -175,7 +175,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_network_info.py
+++ b/plugins/modules/gcp_compute_network_info.py
@@ -179,7 +179,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_node_group_info.py
+++ b/plugins/modules/gcp_compute_node_group_info.py
@@ -153,7 +153,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_node_template_info.py
+++ b/plugins/modules/gcp_compute_node_template_info.py
@@ -177,7 +177,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_region_autoscaler_info.py
+++ b/plugins/modules/gcp_compute_region_autoscaler_info.py
@@ -261,7 +261,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_region_backend_service_info.py
+++ b/plugins/modules/gcp_compute_region_backend_service_info.py
@@ -655,7 +655,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_region_disk_info.py
+++ b/plugins/modules/gcp_compute_region_disk_info.py
@@ -276,7 +276,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_region_health_check_info.py
+++ b/plugins/modules/gcp_compute_region_health_check_info.py
@@ -466,7 +466,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_region_instance_group_manager_info.py
+++ b/plugins/modules/gcp_compute_region_instance_group_manager_info.py
@@ -284,7 +284,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_region_target_http_proxy_info.py
+++ b/plugins/modules/gcp_compute_region_target_http_proxy_info.py
@@ -159,7 +159,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_region_target_https_proxy_info.py
+++ b/plugins/modules/gcp_compute_region_target_https_proxy_info.py
@@ -166,7 +166,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_region_url_map_info.py
+++ b/plugins/modules/gcp_compute_region_url_map_info.py
@@ -1587,7 +1587,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_reservation_info.py
+++ b/plugins/modules/gcp_compute_reservation_info.py
@@ -241,7 +241,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_resource_policy_info.py
+++ b/plugins/modules/gcp_compute_resource_policy_info.py
@@ -279,7 +279,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_route_info.py
+++ b/plugins/modules/gcp_compute_route_info.py
@@ -200,7 +200,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_router_info.py
+++ b/plugins/modules/gcp_compute_router_info.py
@@ -205,7 +205,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_snapshot_info.py
+++ b/plugins/modules/gcp_compute_snapshot_info.py
@@ -224,7 +224,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_ssl_certificate_info.py
+++ b/plugins/modules/gcp_compute_ssl_certificate_info.py
@@ -154,7 +154,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_ssl_policy_info.py
+++ b/plugins/modules/gcp_compute_ssl_policy_info.py
@@ -190,7 +190,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_subnetwork_info.py
+++ b/plugins/modules/gcp_compute_subnetwork_info.py
@@ -204,7 +204,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_target_http_proxy_info.py
+++ b/plugins/modules/gcp_compute_target_http_proxy_info.py
@@ -148,7 +148,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_target_https_proxy_info.py
+++ b/plugins/modules/gcp_compute_target_https_proxy_info.py
@@ -170,7 +170,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_target_instance_info.py
+++ b/plugins/modules/gcp_compute_target_instance_info.py
@@ -161,7 +161,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_target_pool_info.py
+++ b/plugins/modules/gcp_compute_target_pool_info.py
@@ -207,7 +207,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_target_ssl_proxy_info.py
+++ b/plugins/modules/gcp_compute_target_ssl_proxy_info.py
@@ -166,7 +166,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_target_tcp_proxy_info.py
+++ b/plugins/modules/gcp_compute_target_tcp_proxy_info.py
@@ -152,7 +152,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_target_vpn_gateway_info.py
+++ b/plugins/modules/gcp_compute_target_vpn_gateway_info.py
@@ -169,7 +169,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_url_map_info.py
+++ b/plugins/modules/gcp_compute_url_map_info.py
@@ -2467,7 +2467,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_vpn_tunnel_info.py
+++ b/plugins/modules/gcp_compute_vpn_tunnel_info.py
@@ -202,7 +202,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_container_cluster_info.py
+++ b/plugins/modules/gcp_container_cluster_info.py
@@ -763,7 +763,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_container_node_pool_info.py
+++ b/plugins/modules/gcp_container_node_pool_info.py
@@ -422,7 +422,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest, replace_resource_dict
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest, replace_resource_dict
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_dns_managed_zone_info.py
+++ b/plugins/modules/gcp_dns_managed_zone_info.py
@@ -291,7 +291,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_dns_resource_record_set_info.py
+++ b/plugins/modules/gcp_dns_resource_record_set_info.py
@@ -144,7 +144,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest, replace_resource_dict
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest, replace_resource_dict
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_filestore_instance_info.py
+++ b/plugins/modules/gcp_filestore_instance_info.py
@@ -197,7 +197,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_iam_role_info.py
+++ b/plugins/modules/gcp_iam_role_info.py
@@ -140,7 +140,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_iam_service_account_info.py
+++ b/plugins/modules/gcp_iam_service_account_info.py
@@ -139,7 +139,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_iam_service_account_key.py
+++ b/plugins/modules/gcp_iam_service_account_key.py
@@ -198,7 +198,7 @@ path:
 # Imports
 ################################################################################
 
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest, replace_resource_dict
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest, replace_resource_dict
 from ansible.module_utils._text import to_native
 import json
 import os

--- a/plugins/modules/gcp_kms_crypto_key_info.py
+++ b/plugins/modules/gcp_kms_crypto_key_info.py
@@ -176,7 +176,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_kms_key_ring_info.py
+++ b/plugins/modules/gcp_kms_key_ring_info.py
@@ -135,7 +135,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_logging_metric_info.py
+++ b/plugins/modules/gcp_logging_metric_info.py
@@ -286,7 +286,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_mlengine_model_info.py
+++ b/plugins/modules/gcp_mlengine_model_info.py
@@ -153,7 +153,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_mlengine_version_info.py
+++ b/plugins/modules/gcp_mlengine_version_info.py
@@ -244,7 +244,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest, replace_resource_dict
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest, replace_resource_dict
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_pubsub_subscription_info.py
+++ b/plugins/modules/gcp_pubsub_subscription_info.py
@@ -276,7 +276,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_pubsub_topic_info.py
+++ b/plugins/modules/gcp_pubsub_topic_info.py
@@ -145,7 +145,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_redis_instance_info.py
+++ b/plugins/modules/gcp_redis_instance_info.py
@@ -221,7 +221,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_resourcemanager_project_info.py
+++ b/plugins/modules/gcp_resourcemanager_project_info.py
@@ -166,7 +166,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_runtimeconfig_config_info.py
+++ b/plugins/modules/gcp_runtimeconfig_config_info.py
@@ -119,7 +119,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_runtimeconfig_variable_info.py
+++ b/plugins/modules/gcp_runtimeconfig_variable_info.py
@@ -135,7 +135,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_serviceusage_service_info.py
+++ b/plugins/modules/gcp_serviceusage_service_info.py
@@ -162,7 +162,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_sourcerepo_repository_info.py
+++ b/plugins/modules/gcp_sourcerepo_repository_info.py
@@ -126,7 +126,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_spanner_database_info.py
+++ b/plugins/modules/gcp_spanner_database_info.py
@@ -139,7 +139,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest, replace_resource_dict
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest, replace_resource_dict
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_spanner_instance_info.py
+++ b/plugins/modules/gcp_spanner_instance_info.py
@@ -142,7 +142,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_sql_database_info.py
+++ b/plugins/modules/gcp_sql_database_info.py
@@ -142,7 +142,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_sql_instance_info.py
+++ b/plugins/modules/gcp_sql_instance_info.py
@@ -497,7 +497,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_sql_user_info.py
+++ b/plugins/modules/gcp_sql_user_info.py
@@ -142,7 +142,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest, replace_resource_dict
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest, replace_resource_dict
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_storage_object.py
+++ b/plugins/modules/gcp_storage_object.py
@@ -145,7 +145,7 @@ storage_class:
 # Imports
 ################################################################################
 
-from ansible.module_utils.gcp_utils import (
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import (
     navigate_hash,
     GcpSession,
     GcpModule,

--- a/plugins/modules/gcp_tpu_node_info.py
+++ b/plugins/modules/gcp_tpu_node_info.py
@@ -200,7 +200,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################


### PR DESCRIPTION
##### SUMMARY
This is need to work with Ansible 2.10

The version of module_utils inside of Ansible core has been removed, so the collection must rely on the module_utils within the collection itself

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules

##### ADDITIONAL INFORMATION
I might be getting this wrong because the modules are generated by your tool, and not written manually. Even so, I hope this communicates what needs to be changed, however that happens.

Testing imports of the modules via pure python seem to show this version imports, have not tested actually running.
