### PR TITLE
Update gcp_compute_disk.py

### DIFF
--- a/plugins/module_utils/gcp_utils.py
+++ b/plugins/module_utils/gcp_utils.py
@@ -288,8 +288,7 @@ class GcpModule(AnsibleModule):
                 scopes=dict(
                     required=False,
                     fallback=(env_fallback, ['GCP_SCOPES']),
-                    type='list',
-                    elements='str'),
+                    type='list'),
                 env_type=dict(
                     required=False,
                     fallback=(env_fallback, ['GCP_ENV_TYPE']),

--- a/plugins/module_utils/gcp_utils.py
+++ b/plugins/module_utils/gcp_utils.py
@@ -288,7 +288,8 @@ class GcpModule(AnsibleModule):
                 scopes=dict(
                     required=False,
                     fallback=(env_fallback, ['GCP_SCOPES']),
-                    type='list'),
+                    type='list',
+                    elements='str'),
                 env_type=dict(
                     required=False,
                     fallback=(env_fallback, ['GCP_ENV_TYPE']),

--- a/plugins/modules/gcp_appengine_firewall_rule.py
+++ b/plugins/modules/gcp_appengine_firewall_rule.py
@@ -34,7 +34,6 @@ description:
 - A single firewall rule that is evaluated against incoming traffic and provides an
   action to take on matched requests.
 short_description: Creates a GCP FirewallRule
-version_added: '2.9'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -106,6 +105,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_appengine_firewall_rule_info.py
+++ b/plugins/modules/gcp_appengine_firewall_rule_info.py
@@ -33,7 +33,6 @@ module: gcp_appengine_firewall_rule_info
 description:
 - Gather info for GCP FirewallRule
 short_description: Gather info for GCP FirewallRule
-version_added: '2.9'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -71,6 +70,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -134,7 +134,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_bigquery_dataset.py
+++ b/plugins/modules/gcp_bigquery_dataset.py
@@ -33,7 +33,6 @@ module: gcp_bigquery_dataset
 description:
 - Datasets allow you to organize and control access to your tables.
 short_description: Creates a GCP Dataset
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -167,7 +166,6 @@ options:
       the default partition expiration time indicated by this property.'
     required: false
     type: int
-    version_added: '2.9'
   description:
     description:
     - A user-friendly description of the dataset.
@@ -208,7 +206,6 @@ options:
       key.
     required: false
     type: dict
-    version_added: '2.10'
     suboptions:
       kms_key_name:
         description:
@@ -248,6 +245,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_bigquery_dataset.py
+++ b/plugins/modules/gcp_bigquery_dataset.py
@@ -598,11 +598,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/bigquery/v2/projects/{project}/datasets/{name}".format(**module.params)
+    return "https://bigquery.googleapis.com/bigquery/v2/projects/{project}/datasets/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/bigquery/v2/projects/{project}/datasets".format(**module.params)
+    return "https://bigquery.googleapis.com/bigquery/v2/projects/{project}/datasets".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):

--- a/plugins/modules/gcp_bigquery_dataset_info.py
+++ b/plugins/modules/gcp_bigquery_dataset_info.py
@@ -317,7 +317,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/bigquery/v2/projects/{project}/datasets".format(**module.params)
+    return "https://bigquery.googleapis.com/bigquery/v2/projects/{project}/datasets".format(**module.params)
 
 
 def fetch_list(module, link):

--- a/plugins/modules/gcp_bigquery_dataset_info.py
+++ b/plugins/modules/gcp_bigquery_dataset_info.py
@@ -33,7 +33,6 @@ module: gcp_bigquery_dataset_info
 description:
 - Gather info for GCP Dataset
 short_description: Gather info for GCP Dataset
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -71,6 +70,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -298,7 +298,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_bigquery_table.py
+++ b/plugins/modules/gcp_bigquery_table.py
@@ -33,7 +33,6 @@ module: gcp_bigquery_table
 description:
 - A Table that belongs to a Dataset .
 short_description: Creates a GCP Table
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -78,7 +77,6 @@ options:
     elements: str
     required: false
     type: list
-    version_added: '2.9'
   description:
     description:
     - A user-friendly description of the dataset.
@@ -106,7 +104,6 @@ options:
       buffer.
     required: false
     type: int
-    version_added: '2.9'
   view:
     description:
     - The view definition.
@@ -157,7 +154,6 @@ options:
           or REQUIRED.
         required: false
         type: str
-        version_added: '2.9'
       type:
         description:
         - The only type supported is DAY, which will generate one partition per day.
@@ -497,6 +493,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_bigquery_table.py
+++ b/plugins/modules/gcp_bigquery_table.py
@@ -1192,11 +1192,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/bigquery/v2/projects/{project}/datasets/{dataset}/tables/{name}".format(**module.params)
+    return "https://bigquery.googleapis.com/bigquery/v2/projects/{project}/datasets/{dataset}/tables/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/bigquery/v2/projects/{project}/datasets/{dataset}/tables".format(**module.params)
+    return "https://bigquery.googleapis.com/bigquery/v2/projects/{project}/datasets/{dataset}/tables".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):

--- a/plugins/modules/gcp_bigquery_table_info.py
+++ b/plugins/modules/gcp_bigquery_table_info.py
@@ -33,7 +33,6 @@ module: gcp_bigquery_table_info
 description:
 - Gather info for GCP Table
 short_description: Gather info for GCP Table
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -76,6 +75,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -574,7 +574,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_bigquery_table_info.py
+++ b/plugins/modules/gcp_bigquery_table_info.py
@@ -593,7 +593,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/bigquery/v2/projects/{project}/datasets/{dataset}/tables".format(**module.params)
+    return "https://bigquery.googleapis.com/bigquery/v2/projects/{project}/datasets/{dataset}/tables".format(**module.params)
 
 
 def fetch_list(module, link):

--- a/plugins/modules/gcp_bigtable_instance.py
+++ b/plugins/modules/gcp_bigtable_instance.py
@@ -34,7 +34,6 @@ description:
 - A collection of Bigtable Tables and the resources that serve them. All tables in
   an instance are served from all Clusters in the instance.
 short_description: Creates a GCP Instance
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -136,6 +135,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_bigtable_instance_info.py
+++ b/plugins/modules/gcp_bigtable_instance_info.py
@@ -33,7 +33,6 @@ module: gcp_bigtable_instance_info
 description:
 - Gather info for GCP Instance
 short_description: Gather info for GCP Instance
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -71,6 +70,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -172,7 +172,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_cloudbuild_trigger.py
+++ b/plugins/modules/gcp_cloudbuild_trigger.py
@@ -33,7 +33,6 @@ module: gcp_cloudbuild_trigger
 description:
 - Configuration for an automated build in response to source repository changes.
 short_description: Creates a GCP Trigger
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -58,7 +57,6 @@ options:
     - Name of the trigger. Must be unique within the project.
     required: false
     type: str
-    version_added: '2.10'
   description:
     description:
     - Human-readable description of the trigger.
@@ -70,7 +68,6 @@ options:
     elements: str
     required: false
     type: list
-    version_added: '2.10'
   disabled:
     description:
     - Whether the trigger is disabled or not. If true, the trigger will never result
@@ -145,7 +142,6 @@ options:
         - Only trigger a build if the revision regex does NOT match the revision regex.
         required: false
         type: bool
-        version_added: '2.10'
       branch_name:
         description:
         - Name of the branch to build. Exactly one a of branch name, tag, or commit
@@ -178,7 +174,6 @@ options:
         - The location of the source files to build.
         required: false
         type: dict
-        version_added: '2.10'
         suboptions:
           storage_source:
             description:
@@ -286,7 +281,6 @@ options:
         - Substitutions data for Build resource.
         required: false
         type: dict
-        version_added: '2.10'
       queue_ttl:
         description:
         - TTL in queue for this build. If provided and the build is enqueued longer
@@ -296,14 +290,12 @@ options:
           ''s''. Example: "3.5s".'
         required: false
         type: str
-        version_added: '2.10'
       logs_bucket:
         description:
         - Google Cloud Storage bucket where logs should be written. Logs file names
           will be of the format ${logsBucket}/log-${build_id}.txt.
         required: false
         type: str
-        version_added: '2.10'
       timeout:
         description:
         - Amount of time that this build should be allowed to run, to second granularity.
@@ -316,14 +308,12 @@ options:
         required: false
         default: 600s
         type: str
-        version_added: '2.10'
       secrets:
         description:
         - Secrets to decrypt using Cloud Key Management Service.
         elements: dict
         required: false
         type: list
-        version_added: '2.10'
         suboptions:
           kms_key_name:
             description:
@@ -495,6 +485,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_cloudbuild_trigger_info.py
+++ b/plugins/modules/gcp_cloudbuild_trigger_info.py
@@ -33,7 +33,6 @@ module: gcp_cloudbuild_trigger_info
 description:
 - Gather info for GCP Trigger
 short_description: Gather info for GCP Trigger
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -71,6 +70,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -511,7 +511,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_cloudfunctions_cloud_function.py
+++ b/plugins/modules/gcp_cloudfunctions_cloud_function.py
@@ -33,7 +33,6 @@ module: gcp_cloudfunctions_cloud_function
 description:
 - A Cloud Function that contains user computation executed in response to an event.
 short_description: Creates a GCP CloudFunction
-version_added: '2.9'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -189,6 +188,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_cloudfunctions_cloud_function_info.py
+++ b/plugins/modules/gcp_cloudfunctions_cloud_function_info.py
@@ -33,7 +33,6 @@ module: gcp_cloudfunctions_cloud_function_info
 description:
 - Gather info for GCP CloudFunction
 short_description: Gather info for GCP CloudFunction
-version_added: '2.9'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -76,6 +75,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -257,7 +257,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_cloudscheduler_job.py
+++ b/plugins/modules/gcp_cloudscheduler_job.py
@@ -37,7 +37,6 @@ description:
   in one of the supported regions. If your project does not have an App Engine app,
   you must create one.
 short_description: Creates a GCP Job
-version_added: '2.9'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -324,6 +323,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_cloudscheduler_job_info.py
+++ b/plugins/modules/gcp_cloudscheduler_job_info.py
@@ -33,7 +33,6 @@ module: gcp_cloudscheduler_job_info
 description:
 - Gather info for GCP Job
 short_description: Gather info for GCP Job
-version_added: '2.9'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -76,6 +75,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -358,7 +358,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_cloudtasks_queue.py
+++ b/plugins/modules/gcp_cloudtasks_queue.py
@@ -33,7 +33,6 @@ module: gcp_cloudtasks_queue
 description:
 - A named resource to which messages are sent by publishers.
 short_description: Creates a GCP Queue
-version_added: '2.9'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -194,6 +193,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_cloudtasks_queue_info.py
+++ b/plugins/modules/gcp_cloudtasks_queue_info.py
@@ -33,7 +33,6 @@ module: gcp_cloudtasks_queue_info
 description:
 - Gather info for GCP Queue
 short_description: Gather info for GCP Queue
-version_added: '2.9'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -76,6 +75,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -250,7 +250,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_address.py
+++ b/plugins/modules/gcp_compute_address.py
@@ -42,7 +42,6 @@ description:
   a new internal IP address, either by Compute Engine or by you. External IP addresses
   can be either ephemeral or static.
 short_description: Creates a GCP Address
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -71,7 +70,6 @@ options:
     required: false
     default: EXTERNAL
     type: str
-    version_added: '2.7'
   description:
     description:
     - An optional description of this resource.
@@ -95,7 +93,6 @@ options:
     - 'Some valid choices include: "GCE_ENDPOINT"'
     required: false
     type: str
-    version_added: '2.10'
   network_tier:
     description:
     - The networking tier used for configuring this address. If this field is not
@@ -103,7 +100,6 @@ options:
     - 'Some valid choices include: "PREMIUM", "STANDARD"'
     required: false
     type: str
-    version_added: '2.8'
   subnetwork:
     description:
     - The URL of the subnetwork in which to reserve the address. If an IP address
@@ -117,7 +113,6 @@ options:
       }}"'
     required: false
     type: dict
-    version_added: '2.7'
   region:
     description:
     - URL of the region where the regional address resides.
@@ -155,6 +150,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_address.py
+++ b/plugins/modules/gcp_compute_address.py
@@ -365,11 +365,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/addresses/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/addresses/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/addresses".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/addresses".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -432,7 +432,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_address_info.py
+++ b/plugins/modules/gcp_compute_address_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_address_info
 description:
 - Gather info for GCP Address
 short_description: Gather info for GCP Address
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   region:
     description:
     - URL of the region where the regional address resides.
@@ -83,6 +83,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -201,7 +202,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_address_info.py
+++ b/plugins/modules/gcp_compute_address_info.py
@@ -221,7 +221,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/addresses".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/addresses".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_autoscaler.py
+++ b/plugins/modules/gcp_compute_autoscaler.py
@@ -35,7 +35,6 @@ description:
 - Autoscalers allow you to automatically scale virtual machine instances in managed
   instance groups according to an autoscaling policy that you define.
 short_description: Creates a GCP Autoscaler
-version_added: '2.9'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -112,7 +111,6 @@ options:
         required: false
         default: 'ON'
         type: str
-        version_added: '2.10'
       cpu_utilization:
         description:
         - Defines the CPU utilization policy that allows the autoscaler to scale based
@@ -237,6 +235,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_autoscaler.py
+++ b/plugins/modules/gcp_compute_autoscaler.py
@@ -591,11 +591,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/autoscalers/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/autoscalers/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/autoscalers".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/autoscalers".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -653,7 +653,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_autoscaler_info.py
+++ b/plugins/modules/gcp_compute_autoscaler_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_autoscaler_info
 description:
 - Gather info for GCP Autoscaler
 short_description: Gather info for GCP Autoscaler
-version_added: '2.9'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   zone:
     description:
     - URL of the zone where the instance group resides.
@@ -82,6 +82,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -261,7 +262,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_autoscaler_info.py
+++ b/plugins/modules/gcp_compute_autoscaler_info.py
@@ -281,7 +281,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/autoscalers".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/autoscalers".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_backend_bucket.py
+++ b/plugins/modules/gcp_compute_backend_bucket.py
@@ -328,11 +328,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/backendBuckets/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/backendBuckets/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/backendBuckets".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/backendBuckets".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -391,7 +391,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_backend_bucket.py
+++ b/plugins/modules/gcp_compute_backend_bucket.py
@@ -37,7 +37,6 @@ description:
   rather than a backend service. It can send requests for static content to a Cloud
   Storage bucket and requests for dynamic content to a virtual machine instance.
 short_description: Creates a GCP BackendBucket
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -62,7 +61,6 @@ options:
     - Cloud CDN configuration for this Backend Bucket.
     required: false
     type: dict
-    version_added: '2.8'
     suboptions:
       signed_url_cache_max_age_sec:
         description:
@@ -127,6 +125,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_backend_bucket_info.py
+++ b/plugins/modules/gcp_compute_backend_bucket_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_backend_bucket_info
 description:
 - Gather info for GCP BackendBucket
 short_description: Gather info for GCP BackendBucket
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -77,6 +77,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -170,7 +171,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_backend_bucket_info.py
+++ b/plugins/modules/gcp_compute_backend_bucket_info.py
@@ -190,7 +190,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/backendBuckets".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/backendBuckets".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_backend_service.py
+++ b/plugins/modules/gcp_compute_backend_service.py
@@ -1438,7 +1438,7 @@ def update_fields(module, request, response):
 def security_policy_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/global/backendServices/{name}/setSecurityPolicy"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/global/backendServices/{name}/setSecurityPolicy"]).format(**module.params),
         {u'securityPolicy': module.params.get('security_policy')},
     )
 
@@ -1487,11 +1487,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/backendServices/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/backendServices/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/backendServices".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/backendServices".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -1567,7 +1567,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_backend_service.py
+++ b/plugins/modules/gcp_compute_backend_service.py
@@ -37,7 +37,6 @@ description:
 - For managed internal load balancing, use a regional backend service instead.
 - Currently self-managed internal load balancing is only available in beta.
 short_description: Creates a GCP BackendService
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -134,7 +133,6 @@ options:
           must be set.
         required: false
         type: int
-        version_added: '2.9'
       max_rate:
         description:
         - The max requests per second (RPS) of the group.
@@ -159,7 +157,6 @@ options:
           must be set.
         required: false
         type: str
-        version_added: '2.9'
       max_utilization:
         description:
         - Used when balancingMode is UTILIZATION. This ratio defines the CPU utilization
@@ -173,7 +170,6 @@ options:
       is applicable only when the load_balancing_scheme is set to INTERNAL_SELF_MANAGED.
     required: false
     type: dict
-    version_added: '2.10'
     suboptions:
       max_requests_per_connection:
         description:
@@ -221,7 +217,6 @@ options:
       This field is only applicable when locality_lb_policy is set to MAGLEV or RING_HASH.
     required: false
     type: dict
-    version_added: '2.10'
     suboptions:
       http_cookie:
         description:
@@ -338,7 +333,6 @@ options:
         required: false
         default: '3600'
         type: int
-        version_added: '2.8'
   connection_draining:
     description:
     - Settings for connection draining .
@@ -358,7 +352,6 @@ options:
     elements: str
     required: false
     type: list
-    version_added: '2.10'
   description:
     description:
     - An optional description of this resource.
@@ -385,7 +378,6 @@ options:
     - Settings for enabling Cloud Identity Aware Proxy.
     required: false
     type: dict
-    version_added: '2.7'
     suboptions:
       enabled:
         description:
@@ -411,7 +403,6 @@ options:
     required: false
     default: EXTERNAL
     type: str
-    version_added: '2.7'
   locality_lb_policy:
     description:
     - The load balancing algorithm used within the scope of the locality.
@@ -435,7 +426,6 @@ options:
       "ORIGINAL_DESTINATION", "MAGLEV"'
     required: false
     type: str
-    version_added: '2.10'
   name:
     description:
     - Name of the resource. Provided by the client when the resource is created. The
@@ -452,7 +442,6 @@ options:
     - This field is applicable only when the load_balancing_scheme is set to INTERNAL_SELF_MANAGED.
     required: false
     type: dict
-    version_added: '2.10'
     suboptions:
       base_ejection_time:
         description:
@@ -591,7 +580,6 @@ options:
     - The security policy associated with this backend service.
     required: false
     type: str
-    version_added: '2.8'
   session_affinity:
     description:
     - Type of session affinity to use. The default is NONE. Session affinity is not
@@ -615,7 +603,6 @@ options:
     - If logging is enabled, logs will be exported to Stackdriver.
     required: false
     type: dict
-    version_added: '2.10'
     suboptions:
       enable:
         description:
@@ -663,6 +650,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_backend_service_info.py
+++ b/plugins/modules/gcp_compute_backend_service_info.py
@@ -700,7 +700,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/backendServices".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/backendServices".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_backend_service_info.py
+++ b/plugins/modules/gcp_compute_backend_service_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_backend_service_info
 description:
 - Gather info for GCP BackendService
 short_description: Gather info for GCP BackendService
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -77,6 +77,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -680,7 +681,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_disk.py
+++ b/plugins/modules/gcp_compute_disk.py
@@ -43,7 +43,6 @@ description:
 - Add a persistent disk to your instance when you need reliable and affordable storage
   with consistent performance characteristics.
 short_description: Creates a GCP Disk
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -69,7 +68,6 @@ options:
     - Labels to apply to this disk. A list of key->value pairs.
     required: false
     type: dict
-    version_added: '2.7'
   licenses:
     description:
     - Any applicable publicly visible licenses.
@@ -105,14 +103,12 @@ options:
       values for the caller's project.
     required: false
     type: int
-    version_added: '2.8'
   type:
     description:
     - URL of the disk type resource describing which disk type to use to create the
       disk. Provide this when creating the disk.
     required: false
     type: str
-    version_added: '2.7'
   source_image:
     description:
     - The source image used to create this disk. If the source image is deleted, this
@@ -237,6 +233,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_disk.py
+++ b/plugins/modules/gcp_compute_disk.py
@@ -573,7 +573,7 @@ def update_fields(module, request, response):
 def label_fingerprint_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/zones/{zone}/disks/{name}/setLabels"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/zones/{zone}/disks/{name}/setLabels"]).format(**module.params),
         {u'labelFingerprint': response.get('labelFingerprint'), u'labels': module.params.get('labels')},
     )
 
@@ -581,7 +581,7 @@ def label_fingerprint_update(module, request, response):
 def size_gb_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/zones/{zone}/disks/{name}/resize"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/zones/{zone}/disks/{name}/resize"]).format(**module.params),
         {u'sizeGb': module.params.get('size_gb')},
     )
 
@@ -620,11 +620,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/disks/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/disks/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/disks".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/disks".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -690,16 +690,16 @@ def response_to_hash(module, response):
 def disk_type_selflink(name, params):
     if name is None:
         return
-    url = r"https://www.googleapis.com/compute/v1/projects/.*/zones/.*/diskTypes/.*"
+    url = r"https://compute.googleapis.com/compute/v1/projects/.*/zones/.*/diskTypes/.*"
     if not re.match(url, name):
-        name = "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/diskTypes/%s".format(**params) % name
+        name = "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/diskTypes/%s".format(**params) % name
     return name
 
 
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_disk.py
+++ b/plugins/modules/gcp_compute_disk.py
@@ -639,6 +639,7 @@ def resource_to_request(module):
         u'sourceImageEncryptionKey': DiskSourceimageencryptionkey(module.params.get('source_image_encryption_key', {}), module).to_request(),
         u'diskEncryptionKey': DiskDiskencryptionkey(module.params.get('disk_encryption_key', {}), module).to_request(),
         u'sourceSnapshotEncryptionKey': DiskSourcesnapshotencryptionkey(module.params.get('source_snapshot_encryption_key', {}), module).to_request(),
+        u'sourceSnapshot': disk_sourcesnapshot_selflink(module.params.get('source_snapshot', {})),
         u'description': module.params.get('description'),
         u'labels': module.params.get('labels'),
         u'licenses': module.params.get('licenses'),
@@ -654,6 +655,12 @@ def resource_to_request(module):
             return_vals[k] = v
 
     return return_vals
+
+def disk_sourcesnapshot_selflink(sourceSnapshot):
+    if sourceSnapshot and sourceSnapshot['selfLink']:
+        return sourceSnapshot['selfLink']
+    else:
+        return sourceSnapshot
 
 
 def fetch_resource(module, link, kind, allow_not_found=True):

--- a/plugins/modules/gcp_compute_disk_info.py
+++ b/plugins/modules/gcp_compute_disk_info.py
@@ -207,10 +207,10 @@ resources:
       - The source image used to create this disk. If the source image is deleted,
         this field will not be set.
       - 'To create a disk with one of the public operating system images, specify
-        the image by its family name. For example, specify family/debian-8 to use
-        the latest Debian 8 image: projects/debian-cloud/global/images/family/debian-8
+        the image by its family name. For example, specify family/debian-9 to use
+        the latest Debian 9 image: projects/debian-cloud/global/images/family/debian-9
         Alternatively, use a specific version of a public operating system image:
-        projects/debian-cloud/global/images/debian-8-jessie-vYYYYMMDD To create a
+        projects/debian-cloud/global/images/debian-9-stretch-vYYYYMMDD To create a
         disk with a private image that you created, specify the image name in the
         following format: global/images/my-private-image You can also specify a private
         image by its image family, which returns the latest version of the image in
@@ -245,6 +245,12 @@ resources:
         kmsKeyName:
           description:
           - The name of the encryption key that is stored in Google Cloud KMS.
+          returned: success
+          type: str
+        kmsKeyServiceAccount:
+          description:
+          - The service account used for the encryption request for the given KMS
+            key. If absent, the Compute Engine Service Agent service account is used.
           returned: success
           type: str
     sourceImageId:
@@ -289,6 +295,12 @@ resources:
             must have `roles/cloudkms.cryptoKeyEncrypterDecrypter` to use this feature.
           returned: success
           type: str
+        kmsKeyServiceAccount:
+          description:
+          - The service account used for the encryption request for the given KMS
+            key. If absent, the Compute Engine Service Agent service account is used.
+          returned: success
+          type: str
     sourceSnapshot:
       description:
       - The source snapshot used to create this disk. You can provide this as a partial
@@ -317,6 +329,12 @@ resources:
           description:
           - The RFC 4648 base64 encoded SHA-256 hash of the customer-supplied encryption
             key that protects this resource.
+          returned: success
+          type: str
+        kmsKeyServiceAccount:
+          description:
+          - The service account used for the encryption request for the given KMS
+            key. If absent, the Compute Engine Service Agent service account is used.
           returned: success
           type: str
     sourceSnapshotId:

--- a/plugins/modules/gcp_compute_disk_info.py
+++ b/plugins/modules/gcp_compute_disk_info.py
@@ -352,7 +352,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/disks".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/disks".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_disk_info.py
+++ b/plugins/modules/gcp_compute_disk_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_disk_info
 description:
 - Gather info for GCP Disk
 short_description: Gather info for GCP Disk
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   zone:
     description:
     - A reference to the zone where the disk resides.
@@ -82,6 +82,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -332,7 +333,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_external_vpn_gateway.py
+++ b/plugins/modules/gcp_compute_external_vpn_gateway.py
@@ -33,7 +33,6 @@ module: gcp_compute_external_vpn_gateway
 description:
 - Represents a VPN gateway managed outside of GCP.
 short_description: Creates a GCP ExternalVpnGateway
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -88,7 +87,7 @@ options:
         description:
         - IP address of the interface in the external VPN gateway.
         - Only IPv4 is supported. This IP address can be either from your on-premise
-          gateway or another Cloud provider’s VPN gateway, it cannot be an IP address
+          gateway or another Cloud provider's VPN gateway, it cannot be an IP address
           from Google Compute Engine.
         required: false
         type: str
@@ -123,6 +122,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -196,7 +196,7 @@ interfaces:
       description:
       - IP address of the interface in the external VPN gateway.
       - Only IPv4 is supported. This IP address can be either from your on-premise
-        gateway or another Cloud provider’s VPN gateway, it cannot be an IP address
+        gateway or another Cloud provider's VPN gateway, it cannot be an IP address
         from Google Compute Engine.
       returned: success
       type: str

--- a/plugins/modules/gcp_compute_external_vpn_gateway.py
+++ b/plugins/modules/gcp_compute_external_vpn_gateway.py
@@ -303,11 +303,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/externalVpnGateways/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/externalVpnGateways/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/externalVpnGateways".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/externalVpnGateways".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -363,7 +363,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_external_vpn_gateway_info.py
+++ b/plugins/modules/gcp_compute_external_vpn_gateway_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_external_vpn_gateway_info
 description:
 - Gather info for GCP ExternalVpnGateway
 short_description: Gather info for GCP ExternalVpnGateway
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -77,6 +77,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -149,7 +150,7 @@ resources:
           description:
           - IP address of the interface in the external VPN gateway.
           - Only IPv4 is supported. This IP address can be either from your on-premise
-            gateway or another Cloud provider’s VPN gateway, it cannot be an IP address
+            gateway or another Cloud provider's VPN gateway, it cannot be an IP address
             from Google Compute Engine.
           returned: success
           type: str
@@ -158,7 +159,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_external_vpn_gateway_info.py
+++ b/plugins/modules/gcp_compute_external_vpn_gateway_info.py
@@ -178,7 +178,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/externalVpnGateways".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/externalVpnGateways".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_firewall.py
+++ b/plugins/modules/gcp_compute_firewall.py
@@ -642,11 +642,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/firewalls/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/firewalls/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/firewalls".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/firewalls".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -715,7 +715,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_firewall.py
+++ b/plugins/modules/gcp_compute_firewall.py
@@ -40,7 +40,6 @@ description:
   incoming traffic. For all networks except the default network, you must create any
   firewall rules you need.
 short_description: Creates a GCP Firewall
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -88,7 +87,6 @@ options:
     elements: dict
     required: false
     type: list
-    version_added: '2.8'
     suboptions:
       ip_protocol:
         description:
@@ -122,7 +120,6 @@ options:
     elements: str
     required: false
     type: list
-    version_added: '2.8'
   direction:
     description:
     - 'Direction of traffic to which this firewall applies; default is INGRESS. Note:
@@ -131,7 +128,6 @@ options:
     - 'Some valid choices include: "INGRESS", "EGRESS"'
     required: false
     type: str
-    version_added: '2.8'
   disabled:
     description:
     - Denotes whether the firewall rule is disabled, i.e not applied to the network
@@ -140,14 +136,12 @@ options:
       rule will be enabled.
     required: false
     type: bool
-    version_added: '2.8'
   log_config:
     description:
     - This field denotes the logging options for a particular firewall rule.
     - If logging is enabled, logs will be exported to Cloud Logging.
     required: false
     type: dict
-    version_added: '2.10'
     suboptions:
       enable:
         description:
@@ -198,7 +192,6 @@ options:
     required: false
     default: '1000'
     type: int
-    version_added: '2.8'
   source_ranges:
     description:
     - If source ranges are specified, the firewall will apply only to traffic that
@@ -225,7 +218,6 @@ options:
     elements: str
     required: false
     type: list
-    version_added: '2.8'
   source_tags:
     description:
     - If source tags are specified, the firewall will apply only to traffic with source
@@ -249,7 +241,6 @@ options:
     elements: str
     required: false
     type: list
-    version_added: '2.8'
   target_tags:
     description:
     - A list of instance tags indicating sets of instances located in the network
@@ -290,6 +281,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_firewall_info.py
+++ b/plugins/modules/gcp_compute_firewall_info.py
@@ -325,7 +325,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/firewalls".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/firewalls".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_firewall_info.py
+++ b/plugins/modules/gcp_compute_firewall_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_firewall_info
 description:
 - Gather info for GCP Firewall
 short_description: Gather info for GCP Firewall
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -77,6 +77,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -305,7 +306,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_forwarding_rule.py
+++ b/plugins/modules/gcp_compute_forwarding_rule.py
@@ -557,7 +557,7 @@ def update_fields(module, request, response):
 def target_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/regions/{region}/forwardingRules/{name}/setTarget"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/regions/{region}/forwardingRules/{name}/setTarget"]).format(**module.params),
         {u'target': module.params.get('target')},
     )
 
@@ -565,7 +565,7 @@ def target_update(module, request, response):
 def allow_global_access_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.patch(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/regions/{region}/forwardingRules/{name}"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/regions/{region}/forwardingRules/{name}"]).format(**module.params),
         {u'allowGlobalAccess': module.params.get('allow_global_access')},
     )
 
@@ -608,11 +608,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/forwardingRules/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/forwardingRules/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/forwardingRules".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/forwardingRules".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -682,7 +682,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_forwarding_rule.py
+++ b/plugins/modules/gcp_compute_forwarding_rule.py
@@ -35,7 +35,6 @@ description:
   virtual machines to forward a packet to if it matches the given [IPAddress, IPProtocol,
   portRange] tuple.
 short_description: Creates a GCP ForwardingRule
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -177,14 +176,12 @@ options:
     - The forwarded traffic must be of a type appropriate to the target object.
     required: false
     type: str
-    version_added: '2.7'
   allow_global_access:
     description:
     - If true, clients can access ILB from all regions.
     - Otherwise only allows from the local region the ILB is located at.
     required: false
     type: bool
-    version_added: '2.10'
   all_ports:
     description:
     - For internal TCP/UDP load balancing (i.e. load balancing scheme is INTERNAL
@@ -193,7 +190,6 @@ options:
       Used with backend service. Cannot be set if port or portRange are set.
     required: false
     type: bool
-    version_added: '2.8'
   network_tier:
     description:
     - The networking tier used for configuring this address. If this field is not
@@ -201,7 +197,6 @@ options:
     - 'Some valid choices include: "PREMIUM", "STANDARD"'
     required: false
     type: str
-    version_added: '2.8'
   service_label:
     description:
     - An optional prefix to the service name for this Forwarding Rule.
@@ -214,7 +209,6 @@ options:
     - This field is only used for INTERNAL load balancing.
     required: false
     type: str
-    version_added: '2.8'
   region:
     description:
     - A reference to the region where the regional forwarding rule resides.
@@ -252,6 +246,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_forwarding_rule_info.py
+++ b/plugins/modules/gcp_compute_forwarding_rule_info.py
@@ -308,7 +308,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/forwardingRules".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/forwardingRules".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_forwarding_rule_info.py
+++ b/plugins/modules/gcp_compute_forwarding_rule_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_forwarding_rule_info
 description:
 - Gather info for GCP ForwardingRule
 short_description: Gather info for GCP ForwardingRule
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   region:
     description:
     - A reference to the region where the regional forwarding rule resides.
@@ -83,6 +83,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -288,7 +289,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_global_address.py
+++ b/plugins/modules/gcp_compute_global_address.py
@@ -347,11 +347,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/addresses/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/addresses/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/addresses".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/addresses".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -414,16 +414,16 @@ def response_to_hash(module, response):
 def region_selflink(name, params):
     if name is None:
         return
-    url = r"https://www.googleapis.com/compute/v1/projects/.*/regions/.*"
+    url = r"https://compute.googleapis.com/compute/v1/projects/.*/regions/.*"
     if not re.match(url, name):
-        name = "https://www.googleapis.com/compute/v1/projects/{project}/regions/%s".format(**params) % name
+        name = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/%s".format(**params) % name
     return name
 
 
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_global_address.py
+++ b/plugins/modules/gcp_compute_global_address.py
@@ -34,7 +34,6 @@ description:
 - Represents a Global Address resource. Global addresses are used for HTTP(S) load
   balancing.
 short_description: Creates a GCP GlobalAddress
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -54,7 +53,6 @@ options:
     - The static external IP address represented by this resource.
     required: false
     type: str
-    version_added: '2.8'
   description:
     description:
     - An optional description of this resource.
@@ -83,7 +81,6 @@ options:
     - This field is not applicable to addresses with addressType=EXTERNAL.
     required: false
     type: int
-    version_added: '2.9'
   address_type:
     description:
     - The type of the address to reserve.
@@ -93,7 +90,6 @@ options:
     required: false
     default: EXTERNAL
     type: str
-    version_added: '2.8'
   purpose:
     description:
     - The purpose of the resource. For global internal addresses it can be * VPC_PEERING
@@ -101,7 +97,6 @@ options:
     - 'Some valid choices include: "VPC_PEERING"'
     required: false
     type: str
-    version_added: '2.9'
   network:
     description:
     - The URL of the network in which to reserve the IP range. The IP range must be
@@ -115,7 +110,6 @@ options:
       }}"'
     required: false
     type: dict
-    version_added: '2.9'
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -147,6 +141,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_global_address_info.py
+++ b/plugins/modules/gcp_compute_global_address_info.py
@@ -206,7 +206,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/addresses".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/addresses".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_global_address_info.py
+++ b/plugins/modules/gcp_compute_global_address_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_global_address_info
 description:
 - Gather info for GCP GlobalAddress
 short_description: Gather info for GCP GlobalAddress
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -77,6 +77,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -186,7 +187,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_global_forwarding_rule.py
+++ b/plugins/modules/gcp_compute_global_forwarding_rule.py
@@ -37,7 +37,6 @@ description:
 - For more information, see U(https://cloud.google.com/compute/docs/load-balancing/http/)
   .
 short_description: Creates a GCP GlobalForwardingRule
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -122,7 +121,6 @@ options:
     elements: dict
     required: false
     type: list
-    version_added: '2.10'
     suboptions:
       filter_match_criteria:
         description:
@@ -231,6 +229,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_global_forwarding_rule.py
+++ b/plugins/modules/gcp_compute_global_forwarding_rule.py
@@ -562,7 +562,7 @@ def update_fields(module, request, response):
 def target_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/global/forwardingRules/{name}/setTarget"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/global/forwardingRules/{name}/setTarget"]).format(**module.params),
         {u'target': module.params.get('target')},
     )
 
@@ -600,11 +600,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/forwardingRules/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/forwardingRules/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/forwardingRules".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/forwardingRules".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -668,7 +668,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_global_forwarding_rule_info.py
+++ b/plugins/modules/gcp_compute_global_forwarding_rule_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_global_forwarding_rule_info
 description:
 - Gather info for GCP GlobalForwardingRule
 short_description: Gather info for GCP GlobalForwardingRule
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -77,6 +77,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -265,7 +266,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_global_forwarding_rule_info.py
+++ b/plugins/modules/gcp_compute_global_forwarding_rule_info.py
@@ -285,7 +285,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/forwardingRules".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/forwardingRules".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_health_check.py
+++ b/plugins/modules/gcp_compute_health_check.py
@@ -1053,11 +1053,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/healthChecks/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/healthChecks/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/healthChecks".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/healthChecks".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -1124,7 +1124,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_health_check.py
+++ b/plugins/modules/gcp_compute_health_check.py
@@ -41,7 +41,6 @@ description:
   successfully to some number of consecutive probes, it is marked healthy again and
   can receive new connections.
 short_description: Creates a GCP HealthCheck
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -171,7 +170,6 @@ options:
         - 'Some valid choices include: "USE_FIXED_PORT", "USE_NAMED_PORT", "USE_SERVING_PORT"'
         required: false
         type: str
-        version_added: '2.9'
   https_health_check:
     description:
     - A nested object resource.
@@ -233,7 +231,6 @@ options:
         - 'Some valid choices include: "USE_FIXED_PORT", "USE_NAMED_PORT", "USE_SERVING_PORT"'
         required: false
         type: str
-        version_added: '2.9'
   tcp_health_check:
     description:
     - A nested object resource.
@@ -288,7 +285,6 @@ options:
         - 'Some valid choices include: "USE_FIXED_PORT", "USE_NAMED_PORT", "USE_SERVING_PORT"'
         required: false
         type: str
-        version_added: '2.9'
   ssl_health_check:
     description:
     - A nested object resource.
@@ -343,13 +339,11 @@ options:
         - 'Some valid choices include: "USE_FIXED_PORT", "USE_NAMED_PORT", "USE_SERVING_PORT"'
         required: false
         type: str
-        version_added: '2.9'
   http2_health_check:
     description:
     - A nested object resource.
     required: false
     type: dict
-    version_added: '2.10'
     suboptions:
       host:
         description:
@@ -437,6 +431,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_health_check_info.py
+++ b/plugins/modules/gcp_compute_health_check_info.py
@@ -451,6 +451,49 @@ resources:
             and `portName` fields.
           returned: success
           type: str
+    grpcHealthCheck:
+      description:
+      - A nested object resource.
+      returned: success
+      type: complex
+      contains:
+        port:
+          description:
+          - The port number for the health check request. Must be specified if portName
+            and portSpecification are not set or if port_specification is USE_FIXED_PORT.
+            Valid values are 1 through 65535.
+          returned: success
+          type: int
+        portName:
+          description:
+          - Port name as defined in InstanceGroup#NamedPort#name. If both port and
+            port_name are defined, port takes precedence.
+          returned: success
+          type: str
+        portSpecification:
+          description:
+          - 'Specifies how port is selected for health checking, can be one of the
+            following values: * `USE_FIXED_PORT`: The port number in `port` is used
+            for health checking.'
+          - "* `USE_NAMED_PORT`: The `portName` is used for health checking."
+          - "* `USE_SERVING_PORT`: For NetworkEndpointGroup, the port specified for
+            each network endpoint is used for health checking. For other backends,
+            the port or named port specified in the Backend Service is used for health
+            checking."
+          - If not specified, gRPC health check follows behavior specified in `port`
+            and `portName` fields.
+          returned: success
+          type: str
+        grpcServiceName:
+          description:
+          - 'The gRPC service name for the health check. The value of grpcServiceName
+            has the following meanings by convention: - Empty serviceName means the
+            overall status of all services at the backend.'
+          - "- Non-empty serviceName means the health of that gRPC service, as defined
+            by the owner of the service."
+          - The grpcServiceName can only be ASCII.
+          returned: success
+          type: str
 '''
 
 ################################################################################

--- a/plugins/modules/gcp_compute_health_check_info.py
+++ b/plugins/modules/gcp_compute_health_check_info.py
@@ -518,7 +518,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/healthChecks".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/healthChecks".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_health_check_info.py
+++ b/plugins/modules/gcp_compute_health_check_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_health_check_info
 description:
 - Gather info for GCP HealthCheck
 short_description: Gather info for GCP HealthCheck
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -77,6 +77,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -455,7 +456,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_http_health_check.py
+++ b/plugins/modules/gcp_compute_http_health_check.py
@@ -34,7 +34,6 @@ description:
 - An HttpHealthCheck resource. This resource defines a template for how individual
   VMs should be checked for health, via HTTP.
 short_description: Creates a GCP HttpHealthCheck
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -144,6 +143,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_http_health_check.py
+++ b/plugins/modules/gcp_compute_http_health_check.py
@@ -355,11 +355,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/httpHealthChecks/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/httpHealthChecks/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/httpHealthChecks".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/httpHealthChecks".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -422,7 +422,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_http_health_check_info.py
+++ b/plugins/modules/gcp_compute_http_health_check_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_http_health_check_info
 description:
 - Gather info for GCP HttpHealthCheck
 short_description: Gather info for GCP HttpHealthCheck
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -77,6 +77,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -187,7 +188,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_http_health_check_info.py
+++ b/plugins/modules/gcp_compute_http_health_check_info.py
@@ -207,7 +207,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/httpHealthChecks".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/httpHealthChecks".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_https_health_check.py
+++ b/plugins/modules/gcp_compute_https_health_check.py
@@ -352,11 +352,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/httpsHealthChecks/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/httpsHealthChecks/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/httpsHealthChecks".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/httpsHealthChecks".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -419,7 +419,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_https_health_check.py
+++ b/plugins/modules/gcp_compute_https_health_check.py
@@ -34,7 +34,6 @@ description:
 - An HttpsHealthCheck resource. This resource defines a template for how individual
   VMs should be checked for health, via HTTPS.
 short_description: Creates a GCP HttpsHealthCheck
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -141,6 +140,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_https_health_check_info.py
+++ b/plugins/modules/gcp_compute_https_health_check_info.py
@@ -207,7 +207,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/httpsHealthChecks".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/httpsHealthChecks".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_https_health_check_info.py
+++ b/plugins/modules/gcp_compute_https_health_check_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_https_health_check_info
 description:
 - Gather info for GCP HttpsHealthCheck
 short_description: Gather info for GCP HttpsHealthCheck
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -77,6 +77,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -187,7 +188,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_image.py
+++ b/plugins/modules/gcp_compute_image.py
@@ -601,7 +601,7 @@ def update_fields(module, request, response):
 def labels_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/global/images/{name}/setLabels"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/global/images/{name}/setLabels"]).format(**module.params),
         {u'labels': module.params.get('labels'), u'labelFingerprint': response.get('labelFingerprint')},
     )
 
@@ -644,11 +644,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/images/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/images/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/images".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/images".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -720,16 +720,16 @@ def response_to_hash(module, response):
 def license_selflink(name, params):
     if name is None:
         return
-    url = r"https://www.googleapis.com/compute/v1//projects/.*/global/licenses/.*"
+    url = r"https://compute.googleapis.com/compute/v1//projects/.*/global/licenses/.*"
     if not re.match(url, name):
-        name = "https://www.googleapis.com/compute/v1//projects/{project}/global/licenses/%s".format(**params) % name
+        name = "https://compute.googleapis.com/compute/v1//projects/{project}/global/licenses/%s".format(**params) % name
     return name
 
 
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_image.py
+++ b/plugins/modules/gcp_compute_image.py
@@ -186,6 +186,33 @@ options:
       of a given disk name.
     required: false
     type: str
+  source_image:
+    description:
+    - 'URL of the source image used to create this image. In order to create an image,
+      you must provide the full or partial URL of one of the following: The selfLink
+      URL This property The rawDisk.source URL The sourceDisk URL .'
+    - 'This field represents a link to a Image resource in GCP. It can be specified
+      in two ways. First, you can place a dictionary with key ''selfLink'' and value
+      of your resource''s selfLink Alternatively, you can add `register: name-of-resource`
+      to a gcp_compute_image task and then set this source_image field to "{{ name-of-resource
+      }}"'
+    required: false
+    type: dict
+    version_added: '2.10'
+  source_snapshot:
+    description:
+    - URL of the source snapshot used to create this image.
+    - 'In order to create an image, you must provide the full or partial URL of one
+      of the following: The selfLink URL This property The sourceImage URL The rawDisk.source
+      URL The sourceDisk URL .'
+    - 'This field represents a link to a Snapshot resource in GCP. It can be specified
+      in two ways. First, you can place a dictionary with key ''selfLink'' and value
+      of your resource''s selfLink Alternatively, you can add `register: name-of-resource`
+      to a gcp_compute_snapshot task and then set this source_snapshot field to "{{
+      name-of-resource }}"'
+    required: false
+    type: dict
+    version_added: '2.10'
   source_type:
     description:
     - The type of the image used to create this disk. The default and only value is
@@ -460,6 +487,21 @@ sourceDiskId:
     of a given disk name.
   returned: success
   type: str
+sourceImage:
+  description:
+  - 'URL of the source image used to create this image. In order to create an image,
+    you must provide the full or partial URL of one of the following: The selfLink
+    URL This property The rawDisk.source URL The sourceDisk URL .'
+  returned: success
+  type: dict
+sourceSnapshot:
+  description:
+  - URL of the source snapshot used to create this image.
+  - 'In order to create an image, you must provide the full or partial URL of one
+    of the following: The selfLink URL This property The sourceImage URL The rawDisk.source
+    URL The sourceDisk URL .'
+  returned: success
+  type: dict
 sourceType:
   description:
   - The type of the image used to create this disk. The default and only value is
@@ -507,6 +549,8 @@ def main():
             source_disk=dict(type='dict'),
             source_disk_encryption_key=dict(type='dict', options=dict(raw_key=dict(type='str'))),
             source_disk_id=dict(type='str'),
+            source_image=dict(type='dict'),
+            source_snapshot=dict(type='dict'),
             source_type=dict(type='str'),
         )
     )
@@ -585,6 +629,8 @@ def resource_to_request(module):
         u'sourceDisk': replace_resource_dict(module.params.get(u'source_disk', {}), 'selfLink'),
         u'sourceDiskEncryptionKey': ImageSourcediskencryptionkey(module.params.get('source_disk_encryption_key', {}), module).to_request(),
         u'sourceDiskId': module.params.get('source_disk_id'),
+        u'sourceImage': replace_resource_dict(module.params.get(u'source_image', {}), 'selfLink'),
+        u'sourceSnapshot': replace_resource_dict(module.params.get(u'source_snapshot', {}), 'selfLink'),
         u'sourceType': module.params.get('source_type'),
     }
     return_vals = {}
@@ -668,6 +714,8 @@ def response_to_hash(module, response):
         u'sourceDisk': response.get(u'sourceDisk'),
         u'sourceDiskEncryptionKey': ImageSourcediskencryptionkey(response.get(u'sourceDiskEncryptionKey', {}), module).from_response(),
         u'sourceDiskId': response.get(u'sourceDiskId'),
+        u'sourceImage': response.get(u'sourceImage'),
+        u'sourceSnapshot': response.get(u'sourceSnapshot'),
         u'sourceType': response.get(u'sourceType'),
     }
 

--- a/plugins/modules/gcp_compute_image.py
+++ b/plugins/modules/gcp_compute_image.py
@@ -43,7 +43,6 @@ description:
   You can create a custom image from root persistent disks and other images. Then,
   use the custom image to create an instance.
 short_description: Creates a GCP Image
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -111,7 +110,6 @@ options:
     - Labels to apply to this Image.
     required: false
     type: dict
-    version_added: '2.8'
   licenses:
     description:
     - Any applicable license URI.
@@ -198,7 +196,6 @@ options:
       }}"'
     required: false
     type: dict
-    version_added: '2.10'
   source_snapshot:
     description:
     - URL of the source snapshot used to create this image.
@@ -212,7 +209,6 @@ options:
       name-of-resource }}"'
     required: false
     type: dict
-    version_added: '2.10'
   source_type:
     description:
     - The type of the image used to create this disk. The default and only value is
@@ -251,6 +247,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_image_info.py
+++ b/plugins/modules/gcp_compute_image_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_image_info
 description:
 - Gather info for GCP Image
 short_description: Gather info for GCP Image
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -77,6 +77,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -333,7 +334,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_image_info.py
+++ b/plugins/modules/gcp_compute_image_info.py
@@ -307,6 +307,21 @@ resources:
         of a given disk name.
       returned: success
       type: str
+    sourceImage:
+      description:
+      - 'URL of the source image used to create this image. In order to create an
+        image, you must provide the full or partial URL of one of the following: The
+        selfLink URL This property The rawDisk.source URL The sourceDisk URL .'
+      returned: success
+      type: dict
+    sourceSnapshot:
+      description:
+      - URL of the source snapshot used to create this image.
+      - 'In order to create an image, you must provide the full or partial URL of
+        one of the following: The selfLink URL This property The sourceImage URL The
+        rawDisk.source URL The sourceDisk URL .'
+      returned: success
+      type: dict
     sourceType:
       description:
       - The type of the image used to create this disk. The default and only value

--- a/plugins/modules/gcp_compute_image_info.py
+++ b/plugins/modules/gcp_compute_image_info.py
@@ -353,7 +353,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/images".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/images".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_instance.py
+++ b/plugins/modules/gcp_compute_instance.py
@@ -1209,7 +1209,7 @@ def update_fields(module, request, response):
 def label_fingerprint_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/zones/{zone}/instances/{name}/setLabels"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/zones/{zone}/instances/{name}/setLabels"]).format(**module.params),
         {u'labelFingerprint': response.get('labelFingerprint'), u'labels': module.params.get('labels')},
     )
 
@@ -1217,7 +1217,7 @@ def label_fingerprint_update(module, request, response):
 def machine_type_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/zones/{zone}/instances/{name}/setMachineType"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/zones/{zone}/instances/{name}/setMachineType"]).format(**module.params),
         {u'machineType': machine_type_selflink(module.params.get('machine_type'), module.params)},
     )
 
@@ -1262,11 +1262,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instances/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instances/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instances".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instances".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -1342,25 +1342,25 @@ def response_to_hash(module, response):
 def disk_type_selflink(name, params):
     if name is None:
         return
-    url = r"https://www.googleapis.com/compute/v1/projects/.*/zones/.*/diskTypes/.*"
+    url = r"https://compute.googleapis.com/compute/v1/projects/.*/zones/.*/diskTypes/.*"
     if not re.match(url, name):
-        name = "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/diskTypes/%s".format(**params) % name
+        name = "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/diskTypes/%s".format(**params) % name
     return name
 
 
 def machine_type_selflink(name, params):
     if name is None:
         return
-    url = r"https://www.googleapis.com/compute/v1/projects/.*/zones/.*/machineTypes/.*"
+    url = r"https://compute.googleapis.com/compute/v1/projects/.*/zones/.*/machineTypes/.*"
     if not re.match(url, name):
-        name = "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/machineTypes/%s".format(**params) % name
+        name = "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/machineTypes/%s".format(**params) % name
     return name
 
 
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_instance.py
+++ b/plugins/modules/gcp_compute_instance.py
@@ -33,7 +33,6 @@ module: gcp_compute_instance
 description:
 - An instance is a virtual machine (VM) hosted on Google's infrastructure.
 short_description: Creates a GCP Instance
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -62,7 +61,6 @@ options:
     - Whether the resource should be protected against deletion.
     required: false
     type: bool
-    version_added: '2.9'
   disks:
     description:
     - An array of disks that are associated with the instances that are created from
@@ -233,13 +231,11 @@ options:
       when using zonal DNS.
     required: false
     type: str
-    version_added: '2.9'
   labels:
     description:
     - Labels to apply to this instance. A list of key->value pairs.
     required: false
     type: dict
-    version_added: '2.9'
   metadata:
     description:
     - The metadata key/value pairs to assign to instances that are created from this
@@ -319,14 +315,12 @@ options:
               external IP address of the instance to a DNS domain name.
             required: false
             type: bool
-            version_added: '2.10'
           public_ptr_domain_name:
             description:
             - The DNS domain name for the public PTR record. You can set this field
               only if the setPublicPtr field is enabled.
             required: false
             type: str
-            version_added: '2.10'
           network_tier:
             description:
             - This signifies the networking tier used for configuring this access
@@ -338,7 +332,6 @@ options:
             - 'Some valid choices include: "PREMIUM", "STANDARD"'
             required: false
             type: str
-            version_added: '2.10'
       alias_ip_ranges:
         description:
         - An array of alias IP ranges for this network interface. Can only be specified
@@ -448,7 +441,6 @@ options:
     - Configuration for various parameters related to shielded instances.
     required: false
     type: dict
-    version_added: '2.9'
     suboptions:
       enable_secure_boot:
         description:
@@ -475,7 +467,6 @@ options:
       "SUSPENDING", "SUSPENDED", "TERMINATED"'
     required: false
     type: str
-    version_added: '2.8'
   tags:
     description:
     - A list of tags to apply to this instance. Tags are used to identify valid sources
@@ -537,6 +528,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_instance_group.py
+++ b/plugins/modules/gcp_compute_instance_group.py
@@ -377,11 +377,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroups/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroups/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroups".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroups".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -441,16 +441,16 @@ def response_to_hash(module, response):
 def region_selflink(name, params):
     if name is None:
         return
-    url = r"https://www.googleapis.com/compute/v1/projects/.*/regions/.*"
+    url = r"https://compute.googleapis.com/compute/v1/projects/.*/regions/.*"
     if not re.match(url, name):
-        name = "https://www.googleapis.com/compute/v1/projects/{project}/regions/%s".format(**params) % name
+        name = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/%s".format(**params) % name
     return name
 
 
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_instance_group.py
+++ b/plugins/modules/gcp_compute_instance_group.py
@@ -36,7 +36,6 @@ description:
   template. Unlike managed instance groups, you must create and add instances to an
   instance group manually.
 short_description: Creates a GCP InstanceGroup
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -126,7 +125,6 @@ options:
     elements: dict
     required: false
     type: list
-    version_added: '2.8'
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -158,6 +156,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_instance_group_info.py
+++ b/plugins/modules/gcp_compute_instance_group_info.py
@@ -216,7 +216,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroups".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroups".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_instance_group_info.py
+++ b/plugins/modules/gcp_compute_instance_group_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_instance_group_info
 description:
 - Gather info for GCP InstanceGroup
 short_description: Gather info for GCP InstanceGroup
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   zone:
     description:
     - A reference to the zone where the instance group resides.
@@ -82,6 +82,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -196,7 +197,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_instance_group_manager.py
+++ b/plugins/modules/gcp_compute_instance_group_manager.py
@@ -475,11 +475,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -543,16 +543,16 @@ def response_to_hash(module, response):
 def region_selflink(name, params):
     if name is None:
         return
-    url = r"https://www.googleapis.com/compute/v1/projects/.*/regions/.*"
+    url = r"https://compute.googleapis.com/compute/v1/projects/.*/regions/.*"
     if not re.match(url, name):
-        name = "https://www.googleapis.com/compute/v1/projects/{project}/regions/%s".format(**params) % name
+        name = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/%s".format(**params) % name
     return name
 
 
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_instance_group_manager.py
+++ b/plugins/modules/gcp_compute_instance_group_manager.py
@@ -38,7 +38,6 @@ description:
   must separately verify the status of the individual instances.
 - A managed instance group can have up to 1000 VM instances per group.
 short_description: Creates a GCP InstanceGroupManager
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -155,6 +154,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_instance_group_manager_info.py
+++ b/plugins/modules/gcp_compute_instance_group_manager_info.py
@@ -291,7 +291,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instanceGroupManagers".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_instance_group_manager_info.py
+++ b/plugins/modules/gcp_compute_instance_group_manager_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_instance_group_manager_info
 description:
 - Gather info for GCP InstanceGroupManager
 short_description: Gather info for GCP InstanceGroupManager
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   zone:
     description:
     - The zone the managed instance group resides.
@@ -82,6 +82,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -271,7 +272,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_instance_info.py
+++ b/plugins/modules/gcp_compute_instance_info.py
@@ -600,7 +600,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instances".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instances".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_instance_info.py
+++ b/plugins/modules/gcp_compute_instance_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_instance_info
 description:
 - Gather info for GCP Instance
 short_description: Gather info for GCP Instance
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   zone:
     description:
     - A reference to the zone where the machine resides.
@@ -82,6 +82,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -580,7 +581,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_instance_template.py
+++ b/plugins/modules/gcp_compute_instance_template.py
@@ -1139,11 +1139,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/instanceTemplates/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/instanceTemplates/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/instanceTemplates".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/instanceTemplates".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -1203,16 +1203,16 @@ def response_to_hash(module, response):
 def disk_type_selflink(name, params):
     if name is None:
         return
-    url = r"https://www.googleapis.com/compute/v1/projects/.*/zones/.*/diskTypes/.*"
+    url = r"https://compute.googleapis.com/compute/v1/projects/.*/zones/.*/diskTypes/.*"
     if not re.match(url, name):
-        name = "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/diskTypes/%s".format(**params) % name
+        name = "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/diskTypes/%s".format(**params) % name
     return name
 
 
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_instance_template.py
+++ b/plugins/modules/gcp_compute_instance_template.py
@@ -39,7 +39,6 @@ description:
 - 'Tip: Disks should be set to autoDelete=true so that leftover disks are not left
   behind on machine deletion.'
 short_description: Creates a GCP InstanceTemplate
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -236,7 +235,6 @@ options:
         - Labels to apply to this address. A list of key->value pairs.
         required: false
         type: dict
-        version_added: '2.9'
       machine_type:
         description:
         - The machine type to use in the VM instance template.
@@ -326,14 +324,12 @@ options:
                   the external IP address of the instance to a DNS domain name.
                 required: false
                 type: bool
-                version_added: '2.10'
               public_ptr_domain_name:
                 description:
                 - The DNS domain name for the public PTR record. You can set this
                   field only if the setPublicPtr field is enabled.
                 required: false
                 type: str
-                version_added: '2.10'
               network_tier:
                 description:
                 - This signifies the networking tier used for configuring this access
@@ -345,7 +341,6 @@ options:
                 - 'Some valid choices include: "PREMIUM", "STANDARD"'
                 required: false
                 type: str
-                version_added: '2.10'
           alias_ip_ranges:
             description:
             - An array of alias IP ranges for this network interface. Can only be
@@ -508,6 +503,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_instance_template_info.py
+++ b/plugins/modules/gcp_compute_instance_template_info.py
@@ -563,7 +563,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/instanceTemplates".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/instanceTemplates".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_instance_template_info.py
+++ b/plugins/modules/gcp_compute_instance_template_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_instance_template_info
 description:
 - Gather info for GCP InstanceTemplate
 short_description: Gather info for GCP InstanceTemplate
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -77,6 +77,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -543,7 +544,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_interconnect_attachment.py
+++ b/plugins/modules/gcp_compute_interconnect_attachment.py
@@ -34,7 +34,6 @@ description:
 - Represents an InterconnectAttachment (VLAN attachment) resource. For more information,
   see Creating VLAN Attachments.
 short_description: Creates a GCP InterconnectAttachment
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -56,7 +55,6 @@ options:
     required: false
     default: 'true'
     type: bool
-    version_added: '2.9'
   interconnect:
     description:
     - URL of the underlying Interconnect object that this attachment's traffic will
@@ -82,7 +80,6 @@ options:
       "BPS_50G"'
     required: false
     type: str
-    version_added: '2.9'
   edge_availability_domain:
     description:
     - Desired availability domain for the attachment. Only available for type PARTNER,
@@ -176,6 +173,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_interconnect_attachment.py
+++ b/plugins/modules/gcp_compute_interconnect_attachment.py
@@ -456,11 +456,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/interconnectAttachments/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/interconnectAttachments/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/interconnectAttachments".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/interconnectAttachments".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -531,16 +531,16 @@ def response_to_hash(module, response):
 def region_selflink(name, params):
     if name is None:
         return
-    url = r"https://www.googleapis.com/compute/v1/projects/.*/regions/.*"
+    url = r"https://compute.googleapis.com/compute/v1/projects/.*/regions/.*"
     if not re.match(url, name):
-        name = "https://www.googleapis.com/compute/v1/projects/{project}/regions/%s".format(**params) % name
+        name = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/%s".format(**params) % name
     return name
 
 
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_interconnect_attachment_info.py
+++ b/plugins/modules/gcp_compute_interconnect_attachment_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_interconnect_attachment_info
 description:
 - Gather info for GCP InterconnectAttachment
 short_description: Gather info for GCP InterconnectAttachment
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   region:
     description:
     - Region where the regional interconnect attachment resides.
@@ -82,6 +82,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -267,7 +268,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_interconnect_attachment_info.py
+++ b/plugins/modules/gcp_compute_interconnect_attachment_info.py
@@ -287,7 +287,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/interconnectAttachments".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/interconnectAttachments".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_network.py
+++ b/plugins/modules/gcp_compute_network.py
@@ -299,7 +299,7 @@ def update_fields(module, request, response):
 def routing_config_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.patch(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/global/networks/{name}"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/global/networks/{name}"]).format(**module.params),
         {u'routingConfig': NetworkRoutingconfig(module.params.get('routing_config', {}), module).to_request()},
     )
 
@@ -331,11 +331,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/networks/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/networks/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/networks".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/networks".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -395,7 +395,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_network.py
+++ b/plugins/modules/gcp_compute_network.py
@@ -33,7 +33,6 @@ module: gcp_compute_network
 description:
 - Manages a VPC network or legacy network resource on GCP.
 short_description: Creates a GCP Network
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -79,7 +78,6 @@ options:
       to determine what type of network-wide routing behavior to enforce.
     required: false
     type: dict
-    version_added: '2.8'
     suboptions:
       routing_mode:
         description:
@@ -122,6 +120,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_network_endpoint_group.py
+++ b/plugins/modules/gcp_compute_network_endpoint_group.py
@@ -40,7 +40,6 @@ description:
   you can distribute traffic in a granular fashion among applications or containers
   running within VM instances.
 short_description: Creates a GCP NetworkEndpointGroup
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -140,6 +139,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_network_endpoint_group.py
+++ b/plugins/modules/gcp_compute_network_endpoint_group.py
@@ -351,11 +351,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/networkEndpointGroups/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/networkEndpointGroups/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/networkEndpointGroups".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/networkEndpointGroups".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -415,7 +415,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_network_endpoint_group_info.py
+++ b/plugins/modules/gcp_compute_network_endpoint_group_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_network_endpoint_group_info
 description:
 - Gather info for GCP NetworkEndpointGroup
 short_description: Gather info for GCP NetworkEndpointGroup
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   zone:
     description:
     - Zone where the network endpoint group is located.
@@ -82,6 +82,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -175,7 +176,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_network_endpoint_group_info.py
+++ b/plugins/modules/gcp_compute_network_endpoint_group_info.py
@@ -195,7 +195,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/networkEndpointGroups".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/networkEndpointGroups".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_network_info.py
+++ b/plugins/modules/gcp_compute_network_info.py
@@ -199,7 +199,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/networks".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/networks".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_network_info.py
+++ b/plugins/modules/gcp_compute_network_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_network_info
 description:
 - Gather info for GCP Network
 short_description: Gather info for GCP Network
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -77,6 +77,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -179,7 +180,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_node_group.py
+++ b/plugins/modules/gcp_compute_node_group.py
@@ -265,7 +265,7 @@ def update_fields(module, request, response):
 def node_template_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/zones/{zone}/nodeGroups/{name}/setNodeTemplate"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/zones/{zone}/nodeGroups/{name}/setNodeTemplate"]).format(**module.params),
         {u'nodeTemplate': replace_resource_dict(module.params.get(u'node_template', {}), 'selfLink')},
     )
 
@@ -297,15 +297,15 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/nodeGroups/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/nodeGroups/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/nodeGroups".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/nodeGroups".format(**module.params)
 
 
 def create_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/nodeGroups?initialNodeCount={size}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/nodeGroups?initialNodeCount={size}".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -362,25 +362,25 @@ def response_to_hash(module, response):
 def region_selflink(name, params):
     if name is None:
         return
-    url = r"https://www.googleapis.com/compute/v1/projects/.*/regions/.*"
+    url = r"https://compute.googleapis.com/compute/v1/projects/.*/regions/.*"
     if not re.match(url, name):
-        name = "https://www.googleapis.com/compute/v1/projects/{project}/regions/%s".format(**params) % name
+        name = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/%s".format(**params) % name
     return name
 
 
 def zone_selflink(name, params):
     if name is None:
         return
-    url = r"https://www.googleapis.com/compute/v1/projects/.*/zones/.*"
+    url = r"https://compute.googleapis.com/compute/v1/projects/.*/zones/.*"
     if not re.match(url, name):
-        name = "https://www.googleapis.com/compute/v1/projects/{project}/zones/%s".format(**params) % name
+        name = "https://compute.googleapis.com/compute/v1/projects/{project}/zones/%s".format(**params) % name
     return name
 
 
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_node_group.py
+++ b/plugins/modules/gcp_compute_node_group.py
@@ -33,7 +33,6 @@ module: gcp_compute_node_group
 description:
 - Represents a NodeGroup resource to manage a group of sole-tenant nodes.
 short_description: Creates a GCP NodeGroup
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -109,6 +108,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_node_group_info.py
+++ b/plugins/modules/gcp_compute_node_group_info.py
@@ -173,7 +173,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/nodeGroups".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/nodeGroups".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_node_group_info.py
+++ b/plugins/modules/gcp_compute_node_group_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_node_group_info
 description:
 - Gather info for GCP NodeGroup
 short_description: Gather info for GCP NodeGroup
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   zone:
     description:
     - Zone where this node group is located .
@@ -82,6 +82,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -153,7 +154,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_node_template.py
+++ b/plugins/modules/gcp_compute_node_template.py
@@ -321,11 +321,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/nodeTemplates/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/nodeTemplates/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/nodeTemplates".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/nodeTemplates".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -383,16 +383,16 @@ def response_to_hash(module, response):
 def region_selflink(name, params):
     if name is None:
         return
-    url = r"https://www.googleapis.com/compute/v1/projects/.*/regions/.*"
+    url = r"https://compute.googleapis.com/compute/v1/projects/.*/regions/.*"
     if not re.match(url, name):
-        name = "https://www.googleapis.com/compute/v1/projects/{project}/regions/%s".format(**params) % name
+        name = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/%s".format(**params) % name
     return name
 
 
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_node_template.py
+++ b/plugins/modules/gcp_compute_node_template.py
@@ -35,7 +35,6 @@ description:
   sole-tenant nodes, such as node type, vCPU and memory requirements, node affinity
   labels, and region.
 short_description: Creates a GCP NodeTemplate
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -125,6 +124,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_node_template_info.py
+++ b/plugins/modules/gcp_compute_node_template_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_node_template_info
 description:
 - Gather info for GCP NodeTemplate
 short_description: Gather info for GCP NodeTemplate
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   region:
     description:
     - Region where nodes using the node template will be created .
@@ -82,6 +82,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -177,7 +178,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_node_template_info.py
+++ b/plugins/modules/gcp_compute_node_template_info.py
@@ -197,7 +197,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/nodeTemplates".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/nodeTemplates".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_region_autoscaler.py
+++ b/plugins/modules/gcp_compute_region_autoscaler.py
@@ -35,7 +35,6 @@ description:
 - Autoscalers allow you to automatically scale virtual machine instances in managed
   instance groups according to an autoscaling policy that you define.
 short_description: Creates a GCP RegionAutoscaler
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -213,6 +212,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_region_autoscaler.py
+++ b/plugins/modules/gcp_compute_region_autoscaler.py
@@ -563,11 +563,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/autoscalers/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/autoscalers/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/autoscalers".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/autoscalers".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -625,7 +625,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_region_autoscaler_info.py
+++ b/plugins/modules/gcp_compute_region_autoscaler_info.py
@@ -281,7 +281,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/autoscalers".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/autoscalers".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_region_autoscaler_info.py
+++ b/plugins/modules/gcp_compute_region_autoscaler_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_region_autoscaler_info
 description:
 - Gather info for GCP RegionAutoscaler
 short_description: Gather info for GCP RegionAutoscaler
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   region:
     description:
     - URL of the region where the instance group resides.
@@ -82,6 +82,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -261,7 +262,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_region_backend_service.py
+++ b/plugins/modules/gcp_compute_region_backend_service.py
@@ -34,7 +34,6 @@ description:
 - A Region Backend Service defines a regionally-scoped group of virtual machines that
   will serve traffic for load balancing.
 short_description: Creates a GCP RegionBackendService
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -616,6 +615,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_region_backend_service.py
+++ b/plugins/modules/gcp_compute_region_backend_service.py
@@ -1379,11 +1379,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/backendServices/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/backendServices/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/backendServices".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/backendServices".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -1456,7 +1456,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_region_backend_service_info.py
+++ b/plugins/modules/gcp_compute_region_backend_service_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_region_backend_service_info
 description:
 - Gather info for GCP RegionBackendService
 short_description: Gather info for GCP RegionBackendService
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   region:
     description:
     - A reference to the region where the regional backend service resides.
@@ -82,6 +82,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -655,7 +656,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_region_backend_service_info.py
+++ b/plugins/modules/gcp_compute_region_backend_service_info.py
@@ -675,7 +675,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/backendServices".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/backendServices".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_region_disk.py
+++ b/plugins/modules/gcp_compute_region_disk.py
@@ -43,7 +43,6 @@ description:
 - Add a persistent disk to your instance when you need reliable and affordable storage
   with consistent performance characteristics.
 short_description: Creates a GCP RegionDisk
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -195,6 +194,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_region_disk.py
+++ b/plugins/modules/gcp_compute_region_disk.py
@@ -481,7 +481,7 @@ def update_fields(module, request, response):
 def label_fingerprint_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/regions/{region}/disks/{name}/setLabels"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/regions/{region}/disks/{name}/setLabels"]).format(**module.params),
         {u'labelFingerprint': response.get('labelFingerprint'), u'labels': module.params.get('labels')},
     )
 
@@ -489,7 +489,7 @@ def label_fingerprint_update(module, request, response):
 def size_gb_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/regions/{region}/disks/{name}/resize"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/regions/{region}/disks/{name}/resize"]).format(**module.params),
         {u'sizeGb': module.params.get('size_gb')},
     )
 
@@ -527,11 +527,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/disks/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/disks/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/disks".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/disks".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -597,25 +597,25 @@ def response_to_hash(module, response):
 def zone_selflink(name, params):
     if name is None:
         return
-    url = r"https://www.googleapis.com/compute/v1/projects/.*/zones/.*"
+    url = r"https://compute.googleapis.com/compute/v1/projects/.*/zones/.*"
     if not re.match(url, name):
-        name = "https://www.googleapis.com/compute/v1/projects/{project}/zones/%s".format(**params) % name
+        name = "https://compute.googleapis.com/compute/v1/projects/{project}/zones/%s".format(**params) % name
     return name
 
 
 def region_disk_type_selflink(name, params):
     if name is None:
         return
-    url = r"https://www.googleapis.com/compute/v1/projects/.*/regions/.*/diskTypes/.*"
+    url = r"https://compute.googleapis.com/compute/v1/projects/.*/regions/.*/diskTypes/.*"
     if not re.match(url, name):
-        name = "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/diskTypes/%s".format(**params) % name
+        name = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/diskTypes/%s".format(**params) % name
     return name
 
 
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_region_disk_info.py
+++ b/plugins/modules/gcp_compute_region_disk_info.py
@@ -296,7 +296,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/disks".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/disks".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_region_disk_info.py
+++ b/plugins/modules/gcp_compute_region_disk_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_region_disk_info
 description:
 - Gather info for GCP RegionDisk
 short_description: Gather info for GCP RegionDisk
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   region:
     description:
     - A reference to the region where the disk resides.
@@ -82,6 +82,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -276,7 +277,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_region_health_check.py
+++ b/plugins/modules/gcp_compute_region_health_check.py
@@ -1065,11 +1065,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/healthChecks/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/healthChecks/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/healthChecks".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/healthChecks".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -1136,16 +1136,16 @@ def response_to_hash(module, response):
 def region_selflink(name, params):
     if name is None:
         return
-    url = r"https://www.googleapis.com/compute/v1/projects/.*/regions/.*"
+    url = r"https://compute.googleapis.com/compute/v1/projects/.*/regions/.*"
     if not re.match(url, name):
-        name = "https://www.googleapis.com/compute/v1/projects/{project}/regions/%s".format(**params) % name
+        name = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/%s".format(**params) % name
     return name
 
 
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_region_health_check.py
+++ b/plugins/modules/gcp_compute_region_health_check.py
@@ -41,7 +41,6 @@ description:
   successfully to some number of consecutive probes, it is marked healthy again and
   can receive new connections.
 short_description: Creates a GCP RegionHealthCheck
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -435,6 +434,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_region_health_check.py
+++ b/plugins/modules/gcp_compute_region_health_check.py
@@ -398,6 +398,49 @@ options:
         - 'Some valid choices include: "USE_FIXED_PORT", "USE_NAMED_PORT", "USE_SERVING_PORT"'
         required: false
         type: str
+  grpc_health_check:
+    description:
+    - A nested object resource.
+    required: false
+    type: dict
+    suboptions:
+      port:
+        description:
+        - The port number for the health check request. Must be specified if portName
+          and portSpecification are not set or if port_specification is USE_FIXED_PORT.
+          Valid values are 1 through 65535.
+        required: false
+        type: int
+      port_name:
+        description:
+        - Port name as defined in InstanceGroup#NamedPort#name. If both port and port_name
+          are defined, port takes precedence.
+        required: false
+        type: str
+      port_specification:
+        description:
+        - 'Specifies how port is selected for health checking, can be one of the following
+          values: * `USE_FIXED_PORT`: The port number in `port` is used for health
+          checking.'
+        - "* `USE_NAMED_PORT`: The `portName` is used for health checking."
+        - "* `USE_SERVING_PORT`: For NetworkEndpointGroup, the port specified for
+          each network endpoint is used for health checking. For other backends, the
+          port or named port specified in the Backend Service is used for health checking."
+        - If not specified, gRPC health check follows behavior specified in `port`
+          and `portName` fields.
+        - 'Some valid choices include: "USE_FIXED_PORT", "USE_NAMED_PORT", "USE_SERVING_PORT"'
+        required: false
+        type: str
+      grpc_service_name:
+        description:
+        - 'The gRPC service name for the health check. The value of grpcServiceName
+          has the following meanings by convention: - Empty serviceName means the
+          overall status of all services at the backend.'
+        - "- Non-empty serviceName means the health of that gRPC service, as defined
+          by the owner of the service."
+        - The grpcServiceName can only be ASCII.
+        required: false
+        type: str
   region:
     description:
     - The region where the regional health check resides.
@@ -796,6 +839,47 @@ http2HealthCheck:
         and `portName` fields.
       returned: success
       type: str
+grpcHealthCheck:
+  description:
+  - A nested object resource.
+  returned: success
+  type: complex
+  contains:
+    port:
+      description:
+      - The port number for the health check request. Must be specified if portName
+        and portSpecification are not set or if port_specification is USE_FIXED_PORT.
+        Valid values are 1 through 65535.
+      returned: success
+      type: int
+    portName:
+      description:
+      - Port name as defined in InstanceGroup#NamedPort#name. If both port and port_name
+        are defined, port takes precedence.
+      returned: success
+      type: str
+    portSpecification:
+      description:
+      - 'Specifies how port is selected for health checking, can be one of the following
+        values: * `USE_FIXED_PORT`: The port number in `port` is used for health checking.'
+      - "* `USE_NAMED_PORT`: The `portName` is used for health checking."
+      - "* `USE_SERVING_PORT`: For NetworkEndpointGroup, the port specified for each
+        network endpoint is used for health checking. For other backends, the port
+        or named port specified in the Backend Service is used for health checking."
+      - If not specified, gRPC health check follows behavior specified in `port` and
+        `portName` fields.
+      returned: success
+      type: str
+    grpcServiceName:
+      description:
+      - 'The gRPC service name for the health check. The value of grpcServiceName
+        has the following meanings by convention: - Empty serviceName means the overall
+        status of all services at the backend.'
+      - "- Non-empty serviceName means the health of that gRPC service, as defined
+        by the owner of the service."
+      - The grpcServiceName can only be ASCII.
+      returned: success
+      type: str
 region:
   description:
   - The region where the regional health check resides.
@@ -895,6 +979,10 @@ def main():
                     port_specification=dict(type='str'),
                 ),
             ),
+            grpc_health_check=dict(
+                type='dict',
+                options=dict(port=dict(type='int'), port_name=dict(type='str'), port_specification=dict(type='str'), grpc_service_name=dict(type='str')),
+            ),
             region=dict(type='str'),
         )
     )
@@ -961,6 +1049,7 @@ def resource_to_request(module):
         u'tcpHealthCheck': RegionHealthCheckTcphealthcheck(module.params.get('tcp_health_check', {}), module).to_request(),
         u'sslHealthCheck': RegionHealthCheckSslhealthcheck(module.params.get('ssl_health_check', {}), module).to_request(),
         u'http2HealthCheck': RegionHealthCheckHttp2healthcheck(module.params.get('http2_health_check', {}), module).to_request(),
+        u'grpcHealthCheck': RegionHealthCheckGrpchealthcheck(module.params.get('grpc_health_check', {}), module).to_request(),
     }
     return_vals = {}
     for k, v in request.items():
@@ -1040,6 +1129,7 @@ def response_to_hash(module, response):
         u'tcpHealthCheck': RegionHealthCheckTcphealthcheck(response.get(u'tcpHealthCheck', {}), module).from_response(),
         u'sslHealthCheck': RegionHealthCheckSslhealthcheck(response.get(u'sslHealthCheck', {}), module).from_response(),
         u'http2HealthCheck': RegionHealthCheckHttp2healthcheck(response.get(u'http2HealthCheck', {}), module).from_response(),
+        u'grpcHealthCheck': RegionHealthCheckGrpchealthcheck(response.get(u'grpcHealthCheck', {}), module).from_response(),
     }
 
 
@@ -1254,6 +1344,35 @@ class RegionHealthCheckHttp2healthcheck(object):
                 u'portName': self.request.get(u'portName'),
                 u'proxyHeader': self.request.get(u'proxyHeader'),
                 u'portSpecification': self.request.get(u'portSpecification'),
+            }
+        )
+
+
+class RegionHealthCheckGrpchealthcheck(object):
+    def __init__(self, request, module):
+        self.module = module
+        if request:
+            self.request = request
+        else:
+            self.request = {}
+
+    def to_request(self):
+        return remove_nones_from_dict(
+            {
+                u'port': self.request.get('port'),
+                u'portName': self.request.get('port_name'),
+                u'portSpecification': self.request.get('port_specification'),
+                u'grpcServiceName': self.request.get('grpc_service_name'),
+            }
+        )
+
+    def from_response(self):
+        return remove_nones_from_dict(
+            {
+                u'port': self.request.get(u'port'),
+                u'portName': self.request.get(u'portName'),
+                u'portSpecification': self.request.get(u'portSpecification'),
+                u'grpcServiceName': self.request.get(u'grpcServiceName'),
             }
         )
 

--- a/plugins/modules/gcp_compute_region_health_check_info.py
+++ b/plugins/modules/gcp_compute_region_health_check_info.py
@@ -457,6 +457,49 @@ resources:
             and `portName` fields.
           returned: success
           type: str
+    grpcHealthCheck:
+      description:
+      - A nested object resource.
+      returned: success
+      type: complex
+      contains:
+        port:
+          description:
+          - The port number for the health check request. Must be specified if portName
+            and portSpecification are not set or if port_specification is USE_FIXED_PORT.
+            Valid values are 1 through 65535.
+          returned: success
+          type: int
+        portName:
+          description:
+          - Port name as defined in InstanceGroup#NamedPort#name. If both port and
+            port_name are defined, port takes precedence.
+          returned: success
+          type: str
+        portSpecification:
+          description:
+          - 'Specifies how port is selected for health checking, can be one of the
+            following values: * `USE_FIXED_PORT`: The port number in `port` is used
+            for health checking.'
+          - "* `USE_NAMED_PORT`: The `portName` is used for health checking."
+          - "* `USE_SERVING_PORT`: For NetworkEndpointGroup, the port specified for
+            each network endpoint is used for health checking. For other backends,
+            the port or named port specified in the Backend Service is used for health
+            checking."
+          - If not specified, gRPC health check follows behavior specified in `port`
+            and `portName` fields.
+          returned: success
+          type: str
+        grpcServiceName:
+          description:
+          - 'The gRPC service name for the health check. The value of grpcServiceName
+            has the following meanings by convention: - Empty serviceName means the
+            overall status of all services at the backend.'
+          - "- Non-empty serviceName means the health of that gRPC service, as defined
+            by the owner of the service."
+          - The grpcServiceName can only be ASCII.
+          returned: success
+          type: str
     region:
       description:
       - The region where the regional health check resides.

--- a/plugins/modules/gcp_compute_region_health_check_info.py
+++ b/plugins/modules/gcp_compute_region_health_check_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_region_health_check_info
 description:
 - Gather info for GCP RegionHealthCheck
 short_description: Gather info for GCP RegionHealthCheck
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   region:
     description:
     - The region where the regional health check resides.
@@ -82,6 +82,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -466,7 +467,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_region_health_check_info.py
+++ b/plugins/modules/gcp_compute_region_health_check_info.py
@@ -529,7 +529,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/healthChecks".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/healthChecks".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_region_instance_group_manager.py
+++ b/plugins/modules/gcp_compute_region_instance_group_manager.py
@@ -506,11 +506,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/instanceGroupManagers/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/instanceGroupManagers/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/instanceGroupManagers".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/instanceGroupManagers".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -574,7 +574,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_region_instance_group_manager.py
+++ b/plugins/modules/gcp_compute_region_instance_group_manager.py
@@ -38,7 +38,6 @@ description:
   must separately verify the status of the individual instances.
 - A managed instance group can have up to 1000 VM instances per group.
 short_description: Creates a GCP RegionInstanceGroupManager
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -173,6 +172,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_region_instance_group_manager_info.py
+++ b/plugins/modules/gcp_compute_region_instance_group_manager_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_region_instance_group_manager_info
 description:
 - Gather info for GCP RegionInstanceGroupManager
 short_description: Gather info for GCP RegionInstanceGroupManager
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   region:
     description:
     - The region the managed instance group resides.
@@ -82,6 +82,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -284,7 +285,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_region_instance_group_manager_info.py
+++ b/plugins/modules/gcp_compute_region_instance_group_manager_info.py
@@ -304,7 +304,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/instanceGroupManagers".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/instanceGroupManagers".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_region_target_http_proxy.py
+++ b/plugins/modules/gcp_compute_region_target_http_proxy.py
@@ -305,7 +305,9 @@ def update_fields(module, request, response):
 def url_map_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/regions/{region}/targetHttpProxies/{name}/setUrlMap"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/regions/{region}/targetHttpProxies/{name}/setUrlMap"]).format(
+            **module.params
+        ),
         {u'urlMap': replace_resource_dict(module.params.get(u'url_map', {}), 'selfLink')},
     )
 
@@ -337,11 +339,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/targetHttpProxies/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/targetHttpProxies/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/targetHttpProxies".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/targetHttpProxies".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -398,7 +400,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_region_target_http_proxy.py
+++ b/plugins/modules/gcp_compute_region_target_http_proxy.py
@@ -34,7 +34,6 @@ description:
 - Represents a RegionTargetHttpProxy resource, which is used by one or more forwarding
   rules to route incoming HTTP requests to a URL map.
 short_description: Creates a GCP RegionTargetHttpProxy
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -111,6 +110,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_region_target_http_proxy_info.py
+++ b/plugins/modules/gcp_compute_region_target_http_proxy_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_region_target_http_proxy_info
 description:
 - Gather info for GCP RegionTargetHttpProxy
 short_description: Gather info for GCP RegionTargetHttpProxy
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   region:
     description:
     - The region where the regional proxy resides.
@@ -82,6 +82,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -159,7 +160,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_region_target_http_proxy_info.py
+++ b/plugins/modules/gcp_compute_region_target_http_proxy_info.py
@@ -179,7 +179,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/targetHttpProxies".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/targetHttpProxies".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_region_target_https_proxy.py
+++ b/plugins/modules/gcp_compute_region_target_https_proxy.py
@@ -34,7 +34,6 @@ description:
 - Represents a RegionTargetHttpsProxy resource, which is used by one or more forwarding
   rules to route incoming HTTPS requests to a URL map.
 short_description: Creates a GCP RegionTargetHttpsProxy
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -119,6 +118,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_region_target_https_proxy.py
+++ b/plugins/modules/gcp_compute_region_target_https_proxy.py
@@ -361,7 +361,7 @@ def update_fields(module, request, response):
 def ssl_certificates_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/regions/{region}/targetHttpsProxies/{name}/setSslCertificates"]).format(
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/regions/{region}/targetHttpsProxies/{name}/setSslCertificates"]).format(
             **module.params
         ),
         {u'sslCertificates': replace_resource_dict(module.params.get('ssl_certificates', []), 'selfLink')},
@@ -371,7 +371,9 @@ def ssl_certificates_update(module, request, response):
 def url_map_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/regions/{region}/targetHttpsProxies/{name}/setUrlMap"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/regions/{region}/targetHttpsProxies/{name}/setUrlMap"]).format(
+            **module.params
+        ),
         {u'urlMap': replace_resource_dict(module.params.get(u'url_map', {}), 'selfLink')},
     )
 
@@ -404,11 +406,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/targetHttpsProxies/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/targetHttpsProxies/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/targetHttpsProxies".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/targetHttpsProxies".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -466,7 +468,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_region_target_https_proxy_info.py
+++ b/plugins/modules/gcp_compute_region_target_https_proxy_info.py
@@ -186,7 +186,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/targetHttpsProxies".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/targetHttpsProxies".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_region_target_https_proxy_info.py
+++ b/plugins/modules/gcp_compute_region_target_https_proxy_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_region_target_https_proxy_info
 description:
 - Gather info for GCP RegionTargetHttpsProxy
 short_description: Gather info for GCP RegionTargetHttpsProxy
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   region:
     description:
     - The region where the regional proxy resides.
@@ -82,6 +82,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -166,7 +167,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_region_url_map.py
+++ b/plugins/modules/gcp_compute_region_url_map.py
@@ -34,7 +34,6 @@ description:
 - UrlMaps are used to route requests to a backend service based on rules that you
   define for the host and path of an incoming URL.
 short_description: Creates a GCP RegionUrlMap
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -1622,6 +1621,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_region_url_map.py
+++ b/plugins/modules/gcp_compute_region_url_map.py
@@ -3528,11 +3528,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/urlMaps/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/urlMaps/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/urlMaps".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/urlMaps".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -3594,7 +3594,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_region_url_map_info.py
+++ b/plugins/modules/gcp_compute_region_url_map_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_region_url_map_info
 description:
 - Gather info for GCP RegionUrlMap
 short_description: Gather info for GCP RegionUrlMap
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   region:
     description:
     - A reference to the region where the url map resides.
@@ -82,6 +82,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -1587,7 +1588,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_region_url_map_info.py
+++ b/plugins/modules/gcp_compute_region_url_map_info.py
@@ -1607,7 +1607,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/urlMaps".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/urlMaps".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_reservation.py
+++ b/plugins/modules/gcp_compute_reservation.py
@@ -445,7 +445,7 @@ def update_fields(module, request, response):
 def specific_reservation_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/zones/{zone}/reservations/{name}/resize"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/zones/{zone}/reservations/{name}/resize"]).format(**module.params),
         {u'specificReservation': ReservationSpecificreservation(module.params.get('specific_reservation', {}), module).to_request()},
     )
 
@@ -477,11 +477,11 @@ def fetch_resource(module, link, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/reservations/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/reservations/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/reservations".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/reservations".format(**module.params)
 
 
 def return_if_object(module, response, allow_not_found=False):
@@ -541,7 +541,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_reservation.py
+++ b/plugins/modules/gcp_compute_reservation.py
@@ -38,7 +38,6 @@ description:
   preemptible VMs, sole tenant nodes, or other services not listed above like Cloud
   SQL and Dataflow.
 short_description: Creates a GCP Reservation
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -181,6 +180,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_reservation_info.py
+++ b/plugins/modules/gcp_compute_reservation_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_reservation_info
 description:
 - Gather info for GCP Reservation
 short_description: Gather info for GCP Reservation
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   zone:
     description:
     - The zone where the reservation is made.
@@ -82,6 +82,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -241,7 +242,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_reservation_info.py
+++ b/plugins/modules/gcp_compute_reservation_info.py
@@ -261,7 +261,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/reservations".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/reservations".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_resource_policy.py
+++ b/plugins/modules/gcp_compute_resource_policy.py
@@ -561,11 +561,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/resourcePolicies/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/resourcePolicies/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/resourcePolicies".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/resourcePolicies".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -620,7 +620,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_resource_policy.py
+++ b/plugins/modules/gcp_compute_resource_policy.py
@@ -34,7 +34,6 @@ description:
 - A policy that can be attached to a resource to specify or schedule actions on that
   resource.
 short_description: Creates a GCP ResourcePolicy
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -243,6 +242,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_resource_policy_info.py
+++ b/plugins/modules/gcp_compute_resource_policy_info.py
@@ -299,7 +299,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/resourcePolicies".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/resourcePolicies".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_resource_policy_info.py
+++ b/plugins/modules/gcp_compute_resource_policy_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_resource_policy_info
 description:
 - Gather info for GCP ResourcePolicy
 short_description: Gather info for GCP ResourcePolicy
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   region:
     description:
     - Region where resource policy resides.
@@ -82,6 +82,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -279,7 +280,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_route.py
+++ b/plugins/modules/gcp_compute_route.py
@@ -48,7 +48,6 @@ description:
 - A Route resource must have exactly one specification of either nextHopGateway, nextHopInstance,
   nextHopIp, nextHopVpnTunnel, or nextHopIlb.
 short_description: Creates a GCP Route
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -75,7 +74,6 @@ options:
       the resource.
     required: false
     type: str
-    version_added: '2.7'
   name:
     description:
     - Name of the resource. Provided by the client when the resource is created. The
@@ -163,7 +161,6 @@ options:
       field to "{{ name-of-resource }}"'
     required: false
     type: dict
-    version_added: '2.10'
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -195,6 +192,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_route.py
+++ b/plugins/modules/gcp_compute_route.py
@@ -433,11 +433,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/routes/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/routes/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/routes".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/routes".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -501,7 +501,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_route_info.py
+++ b/plugins/modules/gcp_compute_route_info.py
@@ -220,7 +220,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/routes".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/routes".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_route_info.py
+++ b/plugins/modules/gcp_compute_route_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_route_info
 description:
 - Gather info for GCP Route
 short_description: Gather info for GCP Route
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -77,6 +77,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -200,7 +201,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_router.py
+++ b/plugins/modules/gcp_compute_router.py
@@ -405,11 +405,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/routers/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/routers/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/routers".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/routers".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -467,7 +467,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_router.py
+++ b/plugins/modules/gcp_compute_router.py
@@ -33,7 +33,6 @@ module: gcp_compute_router
 description:
 - Represents a Router resource.
 short_description: Creates a GCP Router
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -160,6 +159,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_router_info.py
+++ b/plugins/modules/gcp_compute_router_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_router_info
 description:
 - Gather info for GCP Router
 short_description: Gather info for GCP Router
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   region:
     description:
     - Region where the router resides.
@@ -82,6 +82,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -205,7 +206,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_router_info.py
+++ b/plugins/modules/gcp_compute_router_info.py
@@ -225,7 +225,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/routers".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/routers".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_snapshot.py
+++ b/plugins/modules/gcp_compute_snapshot.py
@@ -398,7 +398,7 @@ def update_fields(module, request, response):
 def labels_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/global/snapshots/{name}/setLabels"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/global/snapshots/{name}/setLabels"]).format(**module.params),
         {u'labels': module.params.get('labels'), u'labelFingerprint': response.get('labelFingerprint')},
     )
 
@@ -431,16 +431,16 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/snapshots/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/snapshots/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/snapshots".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/snapshots".format(**module.params)
 
 
 def create_link(module):
     res = {'project': module.params['project'], 'zone': module.params['zone'], 'source_disk': replace_resource_dict(module.params['source_disk'], 'name')}
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/disks/{source_disk}/createSnapshot".format(**res)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/disks/{source_disk}/createSnapshot".format(**res)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -501,16 +501,16 @@ def response_to_hash(module, response):
 def license_selflink(name, params):
     if name is None:
         return
-    url = r"https://www.googleapis.com/compute/v1//projects/.*/global/licenses/.*"
+    url = r"https://compute.googleapis.com/compute/v1//projects/.*/global/licenses/.*"
     if not re.match(url, name):
-        name = "https://www.googleapis.com/compute/v1//projects/{project}/global/licenses/%s".format(**params) % name
+        name = "https://compute.googleapis.com/compute/v1//projects/{project}/global/licenses/%s".format(**params) % name
     return name
 
 
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/"
+    url = "https://compute.googleapis.com/compute/v1/"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_snapshot.py
+++ b/plugins/modules/gcp_compute_snapshot.py
@@ -41,7 +41,6 @@ description:
   faster and at a much lower cost than if you regularly created a full image of the
   disk.
 short_description: Creates a GCP Snapshot
-version_added: '2.9'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -158,6 +157,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_snapshot_info.py
+++ b/plugins/modules/gcp_compute_snapshot_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_snapshot_info
 description:
 - Gather info for GCP Snapshot
 short_description: Gather info for GCP Snapshot
-version_added: '2.9'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -77,6 +77,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -224,7 +225,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_snapshot_info.py
+++ b/plugins/modules/gcp_compute_snapshot_info.py
@@ -244,7 +244,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/snapshots".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/snapshots".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_ssl_certificate.py
+++ b/plugins/modules/gcp_compute_ssl_certificate.py
@@ -299,11 +299,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/sslCertificates/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/sslCertificates/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/sslCertificates".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/sslCertificates".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -361,7 +361,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_ssl_certificate.py
+++ b/plugins/modules/gcp_compute_ssl_certificate.py
@@ -35,7 +35,6 @@ description:
   a mechanism to upload an SSL key and certificate to the load balancer to serve secure
   connections from the user.
 short_description: Creates a GCP SslCertificate
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -108,6 +107,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_ssl_certificate_info.py
+++ b/plugins/modules/gcp_compute_ssl_certificate_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_ssl_certificate_info
 description:
 - Gather info for GCP SslCertificate
 short_description: Gather info for GCP SslCertificate
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -77,6 +77,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -154,7 +155,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_ssl_certificate_info.py
+++ b/plugins/modules/gcp_compute_ssl_certificate_info.py
@@ -174,7 +174,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/sslCertificates".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/sslCertificates".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_ssl_policy.py
+++ b/plugins/modules/gcp_compute_ssl_policy.py
@@ -34,7 +34,6 @@ description:
 - Represents a SSL policy. SSL policies give you the ability to control the features
   of SSL that your SSL proxy or HTTPS load balancer negotiates.
 short_description: Creates a GCP SslPolicy
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -118,6 +117,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_ssl_policy.py
+++ b/plugins/modules/gcp_compute_ssl_policy.py
@@ -333,11 +333,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/sslPolicies/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/sslPolicies/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/sslPolicies".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/sslPolicies".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -399,7 +399,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_ssl_policy_info.py
+++ b/plugins/modules/gcp_compute_ssl_policy_info.py
@@ -210,7 +210,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/sslPolicies".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/sslPolicies".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_ssl_policy_info.py
+++ b/plugins/modules/gcp_compute_ssl_policy_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_ssl_policy_info
 description:
 - Gather info for GCP SslPolicy
 short_description: Gather info for GCP SslPolicy
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -77,6 +77,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -190,7 +191,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_subnetwork.py
+++ b/plugins/modules/gcp_compute_subnetwork.py
@@ -384,7 +384,9 @@ def update_fields(module, request, response):
 def ip_cidr_range_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/regions/{region}/subnetworks/{name}/expandIpCidrRange"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/regions/{region}/subnetworks/{name}/expandIpCidrRange"]).format(
+            **module.params
+        ),
         {u'ipCidrRange': module.params.get('ip_cidr_range')},
     )
 
@@ -392,7 +394,7 @@ def ip_cidr_range_update(module, request, response):
 def secondary_ip_ranges_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.patch(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/regions/{region}/subnetworks/{name}"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/regions/{region}/subnetworks/{name}"]).format(**module.params),
         {u'secondaryIpRanges': SubnetworkSecondaryiprangesArray(module.params.get('secondary_ip_ranges', []), module).to_request()},
     )
 
@@ -400,7 +402,7 @@ def secondary_ip_ranges_update(module, request, response):
 def private_ip_google_access_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/regions/{region}/subnetworks/{name}/setPrivateIpGoogleAccess"]).format(
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/regions/{region}/subnetworks/{name}/setPrivateIpGoogleAccess"]).format(
             **module.params
         ),
         {u'privateIpGoogleAccess': module.params.get('private_ip_google_access')},
@@ -437,11 +439,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/subnetworks/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/subnetworks/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/subnetworks".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/subnetworks".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -503,7 +505,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_subnetwork.py
+++ b/plugins/modules/gcp_compute_subnetwork.py
@@ -172,7 +172,7 @@ options:
     - This only alters the User Agent string for any API requests.
     type: str
 notes:
-- 'API Reference: U(https://cloud.google.com/compute/docs/reference/rest/beta/subnetworks)'
+- 'API Reference: U(https://cloud.google.com/compute/docs/reference/rest/v1/subnetworks)'
 - 'Private Google Access: U(https://cloud.google.com/vpc/docs/configure-private-google-access)'
 - 'Cloud Networking: U(https://cloud.google.com/vpc/docs/using-vpc)'
 - for authentication, you can set service_account_file using the C(gcp_service_account_file)

--- a/plugins/modules/gcp_compute_subnetwork.py
+++ b/plugins/modules/gcp_compute_subnetwork.py
@@ -49,7 +49,6 @@ description:
   private IP addresses. You can isolate portions of the network, even entire subnets,
   using firewall rules.
 short_description: Creates a GCP Subnetwork
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -107,7 +106,6 @@ options:
     elements: dict
     required: false
     type: list
-    version_added: '2.8'
     suboptions:
       range_name:
         description:
@@ -166,6 +164,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_subnetwork_info.py
+++ b/plugins/modules/gcp_compute_subnetwork_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_subnetwork_info
 description:
 - Gather info for GCP Subnetwork
 short_description: Gather info for GCP Subnetwork
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   region:
     description:
     - The GCP region for this subnetwork.
@@ -82,6 +82,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -204,7 +205,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_subnetwork_info.py
+++ b/plugins/modules/gcp_compute_subnetwork_info.py
@@ -224,7 +224,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/subnetworks".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/subnetworks".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_target_http_proxy.py
+++ b/plugins/modules/gcp_compute_target_http_proxy.py
@@ -292,7 +292,7 @@ def update_fields(module, request, response):
 def url_map_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/targetHttpProxies/{name}/setUrlMap"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/targetHttpProxies/{name}/setUrlMap"]).format(**module.params),
         {u'urlMap': replace_resource_dict(module.params.get(u'url_map', {}), 'selfLink')},
     )
 
@@ -323,11 +323,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/targetHttpProxies/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/targetHttpProxies/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/targetHttpProxies".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/targetHttpProxies".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -384,7 +384,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_target_http_proxy.py
+++ b/plugins/modules/gcp_compute_target_http_proxy.py
@@ -34,7 +34,6 @@ description:
 - Represents a TargetHttpProxy resource, which is used by one or more global forwarding
   rule to route incoming HTTP requests to a URL map.
 short_description: Creates a GCP TargetHttpProxy
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -106,6 +105,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_target_http_proxy_info.py
+++ b/plugins/modules/gcp_compute_target_http_proxy_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_target_http_proxy_info
 description:
 - Gather info for GCP TargetHttpProxy
 short_description: Gather info for GCP TargetHttpProxy
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -77,6 +77,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -148,7 +149,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_target_http_proxy_info.py
+++ b/plugins/modules/gcp_compute_target_http_proxy_info.py
@@ -168,7 +168,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/targetHttpProxies".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/targetHttpProxies".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_target_https_proxy.py
+++ b/plugins/modules/gcp_compute_target_https_proxy.py
@@ -34,7 +34,6 @@ description:
 - Represents a TargetHttpsProxy resource, which is used by one or more global forwarding
   rule to route incoming HTTPS requests to a URL map.
 short_description: Creates a GCP TargetHttpsProxy
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -73,7 +72,6 @@ options:
     - 'Some valid choices include: "NONE", "ENABLE", "DISABLE"'
     required: false
     type: str
-    version_added: '2.7'
   ssl_certificates:
     description:
     - A list of SslCertificate resources that are used to authenticate connections
@@ -93,7 +91,6 @@ options:
       }}"'
     required: false
     type: dict
-    version_added: '2.8'
   url_map:
     description:
     - A reference to the UrlMap resource that defines the mapping from URL to the
@@ -136,6 +133,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_target_https_proxy.py
+++ b/plugins/modules/gcp_compute_target_https_proxy.py
@@ -386,7 +386,7 @@ def update_fields(module, request, response):
 def quic_override_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/global/targetHttpsProxies/{name}/setQuicOverride"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/global/targetHttpsProxies/{name}/setQuicOverride"]).format(**module.params),
         {u'quicOverride': module.params.get('quic_override')},
     )
 
@@ -394,7 +394,7 @@ def quic_override_update(module, request, response):
 def ssl_certificates_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/targetHttpsProxies/{name}/setSslCertificates"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/targetHttpsProxies/{name}/setSslCertificates"]).format(**module.params),
         {u'sslCertificates': replace_resource_dict(module.params.get('ssl_certificates', []), 'selfLink')},
     )
 
@@ -402,7 +402,7 @@ def ssl_certificates_update(module, request, response):
 def ssl_policy_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/global/targetHttpsProxies/{name}/setSslPolicy"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/global/targetHttpsProxies/{name}/setSslPolicy"]).format(**module.params),
         {u'sslPolicy': replace_resource_dict(module.params.get(u'ssl_policy', {}), 'selfLink')},
     )
 
@@ -410,7 +410,7 @@ def ssl_policy_update(module, request, response):
 def url_map_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/targetHttpsProxies/{name}/setUrlMap"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/targetHttpsProxies/{name}/setUrlMap"]).format(**module.params),
         {u'urlMap': replace_resource_dict(module.params.get(u'url_map', {}), 'selfLink')},
     )
 
@@ -444,11 +444,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/targetHttpsProxies/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/targetHttpsProxies/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/targetHttpsProxies".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/targetHttpsProxies".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -508,7 +508,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_target_https_proxy_info.py
+++ b/plugins/modules/gcp_compute_target_https_proxy_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_target_https_proxy_info
 description:
 - Gather info for GCP TargetHttpsProxy
 short_description: Gather info for GCP TargetHttpsProxy
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -77,6 +77,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -170,7 +171,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_target_https_proxy_info.py
+++ b/plugins/modules/gcp_compute_target_https_proxy_info.py
@@ -190,7 +190,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/targetHttpsProxies".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/targetHttpsProxies".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_target_instance.py
+++ b/plugins/modules/gcp_compute_target_instance.py
@@ -37,7 +37,6 @@ description:
   instance contains a single virtual machine instance that receives and handles traffic
   from the corresponding forwarding rules.
 short_description: Creates a GCP TargetInstance
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -123,6 +122,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_target_instance.py
+++ b/plugins/modules/gcp_compute_target_instance.py
@@ -322,11 +322,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/targetInstances/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/targetInstances/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/targetInstances".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/targetInstances".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -383,7 +383,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_target_instance_info.py
+++ b/plugins/modules/gcp_compute_target_instance_info.py
@@ -181,7 +181,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/targetInstances".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/targetInstances".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_target_instance_info.py
+++ b/plugins/modules/gcp_compute_target_instance_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_target_instance_info
 description:
 - Gather info for GCP TargetInstance
 short_description: Gather info for GCP TargetInstance
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   zone:
     description:
     - URL of the zone where the target instance resides.
@@ -82,6 +82,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -161,7 +162,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_target_pool.py
+++ b/plugins/modules/gcp_compute_target_pool.py
@@ -33,7 +33,6 @@ module: gcp_compute_target_pool
 description:
 - Represents a TargetPool resource, used for Load Balancing.
 short_description: Creates a GCP TargetPool
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -165,6 +164,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_target_pool.py
+++ b/plugins/modules/gcp_compute_target_pool.py
@@ -386,11 +386,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/targetPools/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/targetPools/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/targetPools".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/targetPools".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -454,7 +454,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_target_pool_info.py
+++ b/plugins/modules/gcp_compute_target_pool_info.py
@@ -227,7 +227,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/targetPools".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/targetPools".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_target_pool_info.py
+++ b/plugins/modules/gcp_compute_target_pool_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_target_pool_info
 description:
 - Gather info for GCP TargetPool
 short_description: Gather info for GCP TargetPool
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   region:
     description:
     - The region where the target pool resides.
@@ -82,6 +82,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -207,7 +208,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_target_ssl_proxy.py
+++ b/plugins/modules/gcp_compute_target_ssl_proxy.py
@@ -374,7 +374,7 @@ def update_fields(module, request, response):
 def proxy_header_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/global/targetSslProxies/{name}/setProxyHeader"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/global/targetSslProxies/{name}/setProxyHeader"]).format(**module.params),
         {u'proxyHeader': module.params.get('proxy_header')},
     )
 
@@ -382,7 +382,7 @@ def proxy_header_update(module, request, response):
 def service_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/global/targetSslProxies/{name}/setBackendService"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/global/targetSslProxies/{name}/setBackendService"]).format(**module.params),
         {u'service': replace_resource_dict(module.params.get(u'service', {}), 'selfLink')},
     )
 
@@ -390,7 +390,7 @@ def service_update(module, request, response):
 def ssl_certificates_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/global/targetSslProxies/{name}/setSslCertificates"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/global/targetSslProxies/{name}/setSslCertificates"]).format(**module.params),
         {u'sslCertificates': replace_resource_dict(module.params.get('ssl_certificates', []), 'selfLink')},
     )
 
@@ -398,7 +398,7 @@ def ssl_certificates_update(module, request, response):
 def ssl_policy_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/global/targetSslProxies/{name}/setSslPolicy"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/global/targetSslProxies/{name}/setSslPolicy"]).format(**module.params),
         {u'sslPolicy': replace_resource_dict(module.params.get(u'ssl_policy', {}), 'selfLink')},
     )
 
@@ -432,11 +432,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/targetSslProxies/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/targetSslProxies/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/targetSslProxies".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/targetSslProxies".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -496,7 +496,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_target_ssl_proxy.py
+++ b/plugins/modules/gcp_compute_target_ssl_proxy.py
@@ -34,7 +34,6 @@ description:
 - Represents a TargetSslProxy resource, which is used by one or more global forwarding
   rule to route incoming SSL requests to a backend service.
 short_description: Creates a GCP TargetSslProxy
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -100,7 +99,6 @@ options:
       }}"'
     required: false
     type: dict
-    version_added: '2.8'
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -132,6 +130,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_target_ssl_proxy_info.py
+++ b/plugins/modules/gcp_compute_target_ssl_proxy_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_target_ssl_proxy_info
 description:
 - Gather info for GCP TargetSslProxy
 short_description: Gather info for GCP TargetSslProxy
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -77,6 +77,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -166,7 +167,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_target_ssl_proxy_info.py
+++ b/plugins/modules/gcp_compute_target_ssl_proxy_info.py
@@ -186,7 +186,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/targetSslProxies".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/targetSslProxies".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_target_tcp_proxy.py
+++ b/plugins/modules/gcp_compute_target_tcp_proxy.py
@@ -34,7 +34,6 @@ description:
 - Represents a TargetTcpProxy resource, which is used by one or more global forwarding
   rule to route incoming TCP requests to a Backend service.
 short_description: Creates a GCP TargetTcpProxy
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -111,6 +110,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_target_tcp_proxy.py
+++ b/plugins/modules/gcp_compute_target_tcp_proxy.py
@@ -300,7 +300,7 @@ def update_fields(module, request, response):
 def proxy_header_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/global/targetTcpProxies/{name}/setProxyHeader"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/global/targetTcpProxies/{name}/setProxyHeader"]).format(**module.params),
         {u'proxyHeader': module.params.get('proxy_header')},
     )
 
@@ -308,7 +308,7 @@ def proxy_header_update(module, request, response):
 def service_update(module, request, response):
     auth = GcpSession(module, 'compute')
     auth.post(
-        ''.join(["https://www.googleapis.com/compute/v1/", "projects/{project}/global/targetTcpProxies/{name}/setBackendService"]).format(**module.params),
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/global/targetTcpProxies/{name}/setBackendService"]).format(**module.params),
         {u'service': replace_resource_dict(module.params.get(u'service', {}), 'selfLink')},
     )
 
@@ -340,11 +340,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/targetTcpProxies/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/targetTcpProxies/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/targetTcpProxies".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/targetTcpProxies".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -402,7 +402,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_target_tcp_proxy_info.py
+++ b/plugins/modules/gcp_compute_target_tcp_proxy_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_target_tcp_proxy_info
 description:
 - Gather info for GCP TargetTcpProxy
 short_description: Gather info for GCP TargetTcpProxy
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -77,6 +77,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -152,7 +153,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_target_tcp_proxy_info.py
+++ b/plugins/modules/gcp_compute_target_tcp_proxy_info.py
@@ -172,7 +172,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/targetTcpProxies".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/targetTcpProxies".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_target_vpn_gateway.py
+++ b/plugins/modules/gcp_compute_target_vpn_gateway.py
@@ -34,7 +34,6 @@ description:
 - Represents a VPN gateway running in GCP. This virtual device is managed by Google,
   but used only by you.
 short_description: Creates a GCP TargetVpnGateway
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -110,6 +109,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_target_vpn_gateway.py
+++ b/plugins/modules/gcp_compute_target_vpn_gateway.py
@@ -303,11 +303,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/targetVpnGateways/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/targetVpnGateways/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/targetVpnGateways".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/targetVpnGateways".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -366,7 +366,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_target_vpn_gateway_info.py
+++ b/plugins/modules/gcp_compute_target_vpn_gateway_info.py
@@ -189,7 +189,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/targetVpnGateways".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/targetVpnGateways".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_target_vpn_gateway_info.py
+++ b/plugins/modules/gcp_compute_target_vpn_gateway_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_target_vpn_gateway_info
 description:
 - Gather info for GCP TargetVpnGateway
 short_description: Gather info for GCP TargetVpnGateway
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   region:
     description:
     - The region this gateway should sit in.
@@ -82,6 +82,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -169,7 +170,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_url_map.py
+++ b/plugins/modules/gcp_compute_url_map.py
@@ -34,7 +34,6 @@ description:
 - UrlMaps are used to route requests to a backend service based on rules that you
   define for the host and path of an incoming URL.
 short_description: Creates a GCP UrlMap
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -78,7 +77,6 @@ options:
       headerAction specified under pathMatcher.
     required: false
     type: dict
-    version_added: '2.10'
     suboptions:
       request_headers_to_add:
         description:
@@ -224,7 +222,6 @@ options:
           in the UrlMap .
         required: false
         type: dict
-        version_added: '2.10'
         suboptions:
           request_headers_to_add:
             description:
@@ -344,7 +341,6 @@ options:
               Only one of routeAction or urlRedirect must be set.
             required: false
             type: dict
-            version_added: '2.10'
             suboptions:
               cors_policy:
                 description:
@@ -724,7 +720,6 @@ options:
               must not be set.
             required: false
             type: dict
-            version_added: '2.10'
             suboptions:
               host_redirect:
                 description:
@@ -798,7 +793,6 @@ options:
         elements: dict
         required: false
         type: list
-        version_added: '2.10'
         suboptions:
           priority:
             description:
@@ -1585,7 +1579,6 @@ options:
           defaultService or defaultRouteAction must not be set.
         required: false
         type: dict
-        version_added: '2.10'
         suboptions:
           host_redirect:
             description:
@@ -1658,7 +1651,6 @@ options:
         - Only one of defaultRouteAction or defaultUrlRedirect must be set.
         required: false
         type: dict
-        version_added: '2.10'
         suboptions:
           weighted_backend_services:
             description:
@@ -2089,7 +2081,6 @@ options:
       or defaultRouteAction must not be set.
     required: false
     type: dict
-    version_added: '2.10'
     suboptions:
       host_redirect:
         description:
@@ -2159,7 +2150,6 @@ options:
     - Only one of defaultRouteAction or defaultUrlRedirect must be set.
     required: false
     type: dict
-    version_added: '2.10'
     suboptions:
       weighted_backend_services:
         description:
@@ -2575,6 +2565,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_url_map.py
+++ b/plugins/modules/gcp_compute_url_map.py
@@ -5549,11 +5549,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/urlMaps/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/urlMaps/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/urlMaps".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/urlMaps".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -5617,7 +5617,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/global/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_url_map_info.py
+++ b/plugins/modules/gcp_compute_url_map_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_url_map_info
 description:
 - Gather info for GCP UrlMap
 short_description: Gather info for GCP UrlMap
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -77,6 +77,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -2469,7 +2470,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_url_map_info.py
+++ b/plugins/modules/gcp_compute_url_map_info.py
@@ -2489,7 +2489,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/global/urlMaps".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/global/urlMaps".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_compute_vpn_tunnel.py
+++ b/plugins/modules/gcp_compute_vpn_tunnel.py
@@ -33,7 +33,6 @@ module: gcp_compute_vpn_tunnel
 description:
 - VPN tunnel resource.
 short_description: Creates a GCP VpnTunnel
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -154,6 +153,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_compute_vpn_tunnel.py
+++ b/plugins/modules/gcp_compute_vpn_tunnel.py
@@ -414,11 +414,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/vpnTunnels/{name}".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/vpnTunnels/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/vpnTunnels".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/vpnTunnels".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):
@@ -482,7 +482,7 @@ def response_to_hash(module, response):
 def async_op_url(module, extra_data=None):
     if extra_data is None:
         extra_data = {}
-    url = "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
+    url = "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/operations/{op_id}"
     combined = extra_data.copy()
     combined.update(module.params)
     return url.format(**combined)

--- a/plugins/modules/gcp_compute_vpn_tunnel_info.py
+++ b/plugins/modules/gcp_compute_vpn_tunnel_info.py
@@ -33,7 +33,6 @@ module: gcp_compute_vpn_tunnel_info
 description:
 - Gather info for GCP VpnTunnel
 short_description: Gather info for GCP VpnTunnel
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -46,6 +45,7 @@ options:
     - Each additional filter in the list will act be added as an AND condition (filter1
       and filter2) .
     type: list
+    elements: str
   region:
     description:
     - The region where the tunnel is located.
@@ -82,6 +82,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -202,7 +203,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_compute_vpn_tunnel_info.py
+++ b/plugins/modules/gcp_compute_vpn_tunnel_info.py
@@ -222,7 +222,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/vpnTunnels".format(**module.params)
+    return "https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/vpnTunnels".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_container_cluster.py
+++ b/plugins/modules/gcp_container_cluster.py
@@ -33,7 +33,6 @@ module: gcp_container_cluster
 description:
 - A Google Container Engine cluster.
 short_description: Creates a GCP Cluster
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -179,7 +178,6 @@ options:
         elements: dict
         required: false
         type: list
-        version_added: '2.9'
         suboptions:
           accelerator_count:
             description:
@@ -197,14 +195,12 @@ options:
           If unspecified, the default disk type is 'pd-standard' .
         required: false
         type: str
-        version_added: '2.9'
       min_cpu_platform:
         description:
         - Minimum CPU platform to be used by this instance. The instance may be scheduled
           on the specified or newer CPU platform.
         required: false
         type: str
-        version_added: '2.9'
       taints:
         description:
         - List of kubernetes taints to be applied to each node.
@@ -213,7 +209,6 @@ options:
         elements: dict
         required: false
         type: list
-        version_added: '2.9'
         suboptions:
           key:
             description:
@@ -237,7 +232,6 @@ options:
         - Shielded Instance options.
         required: false
         type: dict
-        version_added: '2.10'
         suboptions:
           enable_secure_boot:
             description:
@@ -281,7 +275,6 @@ options:
           is issued.
         required: false
         type: dict
-        version_added: '2.9'
         suboptions:
           issue_client_certificate:
             description:
@@ -318,7 +311,6 @@ options:
     - Configuration for a private cluster.
     required: false
     type: dict
-    version_added: '2.8'
     suboptions:
       enable_private_nodes:
         description:
@@ -354,7 +346,6 @@ options:
       .
     required: false
     type: bool
-    version_added: '2.9'
   addons_config:
     description:
     - Configurations for the various addons available to run in the cluster.
@@ -397,7 +388,6 @@ options:
           for the nodes.
         required: false
         type: dict
-        version_added: '2.9'
         suboptions:
           disabled:
             description:
@@ -418,20 +408,17 @@ options:
     type: list
     aliases:
     - nodeLocations
-    version_added: '2.9'
   resource_labels:
     description:
     - The resource labels for the cluster to use to annotate any related Google Compute
       Engine resources.
     required: false
     type: dict
-    version_added: '2.9'
   legacy_abac:
     description:
     - Configuration for the legacy ABAC authorization mode.
     required: false
     type: dict
-    version_added: '2.9'
     suboptions:
       enabled:
         description:
@@ -446,7 +433,6 @@ options:
     - Configuration options for the NetworkPolicy feature.
     required: false
     type: dict
-    version_added: '2.9'
     suboptions:
       provider:
         description:
@@ -466,7 +452,6 @@ options:
     - Only honored if cluster created with IP Alias support.
     required: false
     type: dict
-    version_added: '2.9'
     suboptions:
       max_pods_per_node:
         description:
@@ -478,7 +463,6 @@ options:
     - Configuration for controlling how IPs are allocated in the cluster.
     required: false
     type: dict
-    version_added: '2.9'
     suboptions:
       use_ip_aliases:
         description:
@@ -553,13 +537,11 @@ options:
       when it was first created. The version can be upgraded over time.
     required: false
     type: str
-    version_added: '2.10'
   master_authorized_networks_config:
     description:
     - Configuration for controlling how IPs are allocated in the cluster.
     required: false
     type: dict
-    version_added: '2.10'
     suboptions:
       enabled:
         description:
@@ -589,7 +571,6 @@ options:
     - Configuration for the BinaryAuthorization feature.
     required: false
     type: dict
-    version_added: '2.10'
     suboptions:
       enabled:
         description:
@@ -603,7 +584,6 @@ options:
     type: str
     aliases:
     - zone
-    version_added: '2.8'
   kubectl_path:
     description:
     - The path that the kubectl config file will be written to.
@@ -612,14 +592,12 @@ options:
     - This requires the PyYaml library.
     required: false
     type: str
-    version_added: '2.9'
   kubectl_context:
     description:
     - The name of the context for the kubectl config file. Will default to the cluster
       name.
     required: false
     type: str
-    version_added: '2.9'
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -651,6 +629,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -1717,9 +1696,7 @@ class Kubectl(object):
 
         return {
             'apiVersion': 'v1',
-            'clusters': [
-                {'name': context, 'cluster': {'certificate-authority-data': str(self.fetch['masterAuth']['clusterCaCertificate']), 'server': endpoint,}}
-            ],
+            'clusters': [{'name': context, 'cluster': {'certificate-authority-data': str(self.fetch['masterAuth']['clusterCaCertificate'])}}],
             'contexts': [{'name': context, 'context': {'cluster': context, 'user': context}}],
             'current-context': context,
             'kind': 'Config',

--- a/plugins/modules/gcp_container_cluster_info.py
+++ b/plugins/modules/gcp_container_cluster_info.py
@@ -33,7 +33,6 @@ module: gcp_container_cluster_info
 description:
 - Gather info for GCP Cluster
 short_description: Gather info for GCP Cluster
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -48,7 +47,6 @@ options:
     aliases:
     - region
     - zone
-    version_added: '2.8'
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -80,6 +78,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -763,7 +762,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_container_node_pool.py
+++ b/plugins/modules/gcp_container_node_pool.py
@@ -37,7 +37,6 @@ description:
   applied to them, which may be used to reference them during pod scheduling. They
   may also be resized up or down, to accommodate the workload.
 short_description: Creates a GCP NodePool
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -158,7 +157,6 @@ options:
         elements: dict
         required: false
         type: list
-        version_added: '2.9'
         suboptions:
           accelerator_count:
             description:
@@ -176,21 +174,18 @@ options:
           If unspecified, the default disk type is 'pd-standard' .
         required: false
         type: str
-        version_added: '2.9'
       min_cpu_platform:
         description:
         - Minimum CPU platform to be used by this instance. The instance may be scheduled
           on the specified or newer CPU platform .
         required: false
         type: str
-        version_added: '2.9'
       taints:
         description:
         - List of kubernetes taints to be applied to each node.
         elements: dict
         required: false
         type: list
-        version_added: '2.9'
         suboptions:
           key:
             description:
@@ -212,7 +207,6 @@ options:
         - Shielded Instance options.
         required: false
         type: dict
-        version_added: '2.10'
         suboptions:
           enable_secure_boot:
             description:
@@ -243,7 +237,6 @@ options:
     - The version of the Kubernetes of this node.
     required: false
     type: str
-    version_added: '2.8'
   autoscaling:
     description:
     - Autoscaler configuration for this NodePool. Autoscaler is enabled only if a
@@ -300,7 +293,6 @@ options:
       on a node in the node pool.
     required: false
     type: dict
-    version_added: '2.9'
     suboptions:
       max_pods_per_node:
         description:
@@ -313,7 +305,6 @@ options:
     elements: dict
     required: false
     type: list
-    version_added: '2.9'
     suboptions:
       code:
         description:
@@ -340,7 +331,6 @@ options:
     aliases:
     - region
     - zone
-    version_added: '2.8'
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -372,6 +362,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_container_node_pool_info.py
+++ b/plugins/modules/gcp_container_node_pool_info.py
@@ -33,7 +33,6 @@ module: gcp_container_node_pool_info
 description:
 - Gather info for GCP NodePool
 short_description: Gather info for GCP NodePool
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -48,7 +47,6 @@ options:
     aliases:
     - region
     - zone
-    version_added: '2.8'
   cluster:
     description:
     - The cluster this node pool belongs to.
@@ -90,6 +88,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -422,7 +421,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest, replace_resource_dict
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest, replace_resource_dict
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_dns_managed_zone.py
+++ b/plugins/modules/gcp_dns_managed_zone.py
@@ -606,11 +606,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/dns/v1/projects/{project}/managedZones/{name}".format(**module.params)
+    return "https://dns.googleapis.com/dns/v1/projects/{project}/managedZones/{name}".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/dns/v1/projects/{project}/managedZones".format(**module.params)
+    return "https://dns.googleapis.com/dns/v1/projects/{project}/managedZones".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):

--- a/plugins/modules/gcp_dns_managed_zone.py
+++ b/plugins/modules/gcp_dns_managed_zone.py
@@ -34,7 +34,6 @@ description:
 - A zone is a subtree of the DNS namespace under one administrative responsibility.
   A ManagedZone is a resource that represents a DNS zone hosted by the Cloud DNS service.
 short_description: Creates a GCP ManagedZone
-version_added: '2.5'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -65,7 +64,6 @@ options:
     - DNSSEC configuration.
     required: false
     type: dict
-    version_added: '2.9'
     suboptions:
       kind:
         description:
@@ -143,7 +141,6 @@ options:
     - A set of key/value label pairs to assign to this ManagedZone.
     required: false
     type: dict
-    version_added: '2.8'
   visibility:
     description:
     - 'The zone''s visibility: public zones are exposed to the Internet, while private
@@ -152,14 +149,12 @@ options:
     required: false
     default: public
     type: str
-    version_added: '2.8'
   private_visibility_config:
     description:
     - For privately visible zones, the set of Virtual Private Cloud resources that
       the zone is visible from.
     required: false
     type: dict
-    version_added: '2.8'
     suboptions:
       networks:
         description:
@@ -182,7 +177,6 @@ options:
       to.
     required: false
     type: dict
-    version_added: '2.10'
     suboptions:
       target_name_servers:
         description:
@@ -213,7 +207,6 @@ options:
       The value of this field contains the network to peer with.
     required: false
     type: dict
-    version_added: '2.10'
     suboptions:
       target_network:
         description:
@@ -259,6 +252,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_dns_managed_zone_info.py
+++ b/plugins/modules/gcp_dns_managed_zone_info.py
@@ -33,7 +33,6 @@ module: gcp_dns_managed_zone_info
 description:
 - Gather info for GCP ManagedZone
 short_description: Gather info for GCP ManagedZone
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -44,6 +43,7 @@ options:
     description:
     - Restricts the list to return only zones with this domain name.
     type: list
+    elements: str
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -75,6 +75,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -291,7 +292,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_dns_managed_zone_info.py
+++ b/plugins/modules/gcp_dns_managed_zone_info.py
@@ -311,7 +311,7 @@ def main():
 
 
 def collection(module):
-    return "https://www.googleapis.com/dns/v1/projects/{project}/managedZones".format(**module.params)
+    return "https://dns.googleapis.com/dns/v1/projects/{project}/managedZones".format(**module.params)
 
 
 def fetch_list(module, link, query):

--- a/plugins/modules/gcp_dns_resource_record_set.py
+++ b/plugins/modules/gcp_dns_resource_record_set.py
@@ -37,7 +37,6 @@ description:
 - The record will include the domain/subdomain name, a type (i.e. A, AAA, CAA, MX,
   CNAME, NS, etc) .
 short_description: Creates a GCP ResourceRecordSet
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -113,6 +112,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_dns_resource_record_set.py
+++ b/plugins/modules/gcp_dns_resource_record_set.py
@@ -309,12 +309,12 @@ def self_link(module):
         'name': module.params['name'],
         'type': module.params['type'],
     }
-    return "https://www.googleapis.com/dns/v1/projects/{project}/managedZones/{managed_zone}/rrsets?name={name}&type={type}".format(**res)
+    return "https://dns.googleapis.com/dns/v1/projects/{project}/managedZones/{managed_zone}/rrsets?name={name}&type={type}".format(**res)
 
 
 def collection(module):
     res = {'project': module.params['project'], 'managed_zone': replace_resource_dict(module.params['managed_zone'], 'name')}
-    return "https://www.googleapis.com/dns/v1/projects/{project}/managedZones/{managed_zone}/changes".format(**res)
+    return "https://dns.googleapis.com/dns/v1/projects/{project}/managedZones/{managed_zone}/changes".format(**res)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):

--- a/plugins/modules/gcp_dns_resource_record_set_info.py
+++ b/plugins/modules/gcp_dns_resource_record_set_info.py
@@ -164,7 +164,7 @@ def main():
 
 def collection(module):
     res = {'project': module.params['project'], 'managed_zone': replace_resource_dict(module.params['managed_zone'], 'name')}
-    return "https://www.googleapis.com/dns/v1/projects/{project}/managedZones/{managed_zone}/rrsets".format(**res)
+    return "https://dns.googleapis.com/dns/v1/projects/{project}/managedZones/{managed_zone}/rrsets".format(**res)
 
 
 def fetch_list(module, link):

--- a/plugins/modules/gcp_dns_resource_record_set_info.py
+++ b/plugins/modules/gcp_dns_resource_record_set_info.py
@@ -33,7 +33,6 @@ module: gcp_dns_resource_record_set_info
 description:
 - Gather info for GCP ResourceRecordSet
 short_description: Gather info for GCP ResourceRecordSet
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -78,6 +77,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -144,7 +144,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest, replace_resource_dict
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest, replace_resource_dict
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_filestore_instance.py
+++ b/plugins/modules/gcp_filestore_instance.py
@@ -33,7 +33,6 @@ module: gcp_filestore_instance
 description:
 - A Google Cloud Filestore instance.
 short_description: Creates a GCP Instance
-version_added: '2.9'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -150,6 +149,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_filestore_instance_info.py
+++ b/plugins/modules/gcp_filestore_instance_info.py
@@ -33,7 +33,6 @@ module: gcp_filestore_instance_info
 description:
 - Gather info for GCP Instance
 short_description: Gather info for GCP Instance
-version_added: '2.9'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -76,6 +75,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -197,7 +197,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_iam_role.py
+++ b/plugins/modules/gcp_iam_role.py
@@ -33,7 +33,6 @@ module: gcp_iam_role
 description:
 - A role in the Identity and Access Management API .
 short_description: Creates a GCP Role
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -108,6 +107,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_iam_role_info.py
+++ b/plugins/modules/gcp_iam_role_info.py
@@ -33,7 +33,6 @@ module: gcp_iam_role_info
 description:
 - Gather info for GCP Role
 short_description: Gather info for GCP Role
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -71,6 +70,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -140,7 +140,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_iam_service_account.py
+++ b/plugins/modules/gcp_iam_service_account.py
@@ -33,7 +33,6 @@ module: gcp_iam_service_account
 description:
 - A service account in the Identity and Access Management API.
 short_description: Creates a GCP ServiceAccount
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -89,6 +88,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_iam_service_account_info.py
+++ b/plugins/modules/gcp_iam_service_account_info.py
@@ -33,7 +33,6 @@ module: gcp_iam_service_account_info
 description:
 - Gather info for GCP ServiceAccount
 short_description: Gather info for GCP ServiceAccount
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -71,6 +70,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -139,7 +139,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_iam_service_account_key.py
+++ b/plugins/modules/gcp_iam_service_account_key.py
@@ -33,7 +33,6 @@ module: gcp_iam_service_account_key
 description:
 - A service account in the Identity and Access Management API.
 short_description: Creates a GCP ServiceAccountKey
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -108,6 +107,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -198,7 +198,7 @@ path:
 # Imports
 ################################################################################
 
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest, replace_resource_dict
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest, replace_resource_dict
 from ansible.module_utils._text import to_native
 import json
 import os

--- a/plugins/modules/gcp_kms_crypto_key.py
+++ b/plugins/modules/gcp_kms_crypto_key.py
@@ -33,7 +33,6 @@ module: gcp_kms_crypto_key
 description:
 - A `CryptoKey` represents a logical key that can be used for cryptographic operations.
 short_description: Creates a GCP CryptoKey
-version_added: '2.9'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -131,6 +130,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_kms_crypto_key_info.py
+++ b/plugins/modules/gcp_kms_crypto_key_info.py
@@ -33,7 +33,6 @@ module: gcp_kms_crypto_key_info
 description:
 - Gather info for GCP CryptoKey
 short_description: Gather info for GCP CryptoKey
-version_added: '2.9'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -77,6 +76,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -176,7 +176,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_kms_key_ring.py
+++ b/plugins/modules/gcp_kms_key_ring.py
@@ -33,7 +33,6 @@ module: gcp_kms_key_ring
 description:
 - A `KeyRing` is a toplevel logical grouping of `CryptoKeys`.
 short_description: Creates a GCP KeyRing
-version_added: '2.9'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -91,6 +90,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_kms_key_ring_info.py
+++ b/plugins/modules/gcp_kms_key_ring_info.py
@@ -33,7 +33,6 @@ module: gcp_kms_key_ring_info
 description:
 - Gather info for GCP KeyRing
 short_description: Gather info for GCP KeyRing
-version_added: '2.9'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -78,6 +77,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -135,7 +135,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_logging_metric.py
+++ b/plugins/modules/gcp_logging_metric.py
@@ -35,7 +35,6 @@ description:
   of the values. The distribution records the statistics of the extracted values along
   with an optional histogram of the values as specified by the bucket options.
 short_description: Creates a GCP Metric
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -258,6 +257,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_logging_metric_info.py
+++ b/plugins/modules/gcp_logging_metric_info.py
@@ -33,7 +33,6 @@ module: gcp_logging_metric_info
 description:
 - Gather info for GCP Metric
 short_description: Gather info for GCP Metric
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -71,6 +70,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -286,7 +286,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_mlengine_model.py
+++ b/plugins/modules/gcp_mlengine_model.py
@@ -35,7 +35,6 @@ description:
 - A model can have multiple versions, each of which is a deployed, trained model ready
   to receive prediction requests. The model itself is just a container.
 short_description: Creates a GCP Model
-version_added: '2.9'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -126,6 +125,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_mlengine_model_info.py
+++ b/plugins/modules/gcp_mlengine_model_info.py
@@ -33,7 +33,6 @@ module: gcp_mlengine_model_info
 description:
 - Gather info for GCP Model
 short_description: Gather info for GCP Model
-version_added: '2.9'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -71,6 +70,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -153,7 +153,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_mlengine_version.py
+++ b/plugins/modules/gcp_mlengine_version.py
@@ -34,7 +34,6 @@ description:
 - Each version is a trained model deployed in the cloud, ready to handle prediction
   requests. A model can have multiple versions .
 short_description: Creates a GCP Version
-version_added: '2.9'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -189,6 +188,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_mlengine_version_info.py
+++ b/plugins/modules/gcp_mlengine_version_info.py
@@ -33,7 +33,6 @@ module: gcp_mlengine_version_info
 description:
 - Gather info for GCP Version
 short_description: Gather info for GCP Version
-version_added: '2.9'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -81,6 +80,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -244,7 +244,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest, replace_resource_dict
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest, replace_resource_dict
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_pubsub_subscription.py
+++ b/plugins/modules/gcp_pubsub_subscription.py
@@ -227,6 +227,13 @@ options:
         - If this parameter is 0, a default value of 5 is used.
         required: false
         type: int
+  enable_message_ordering:
+    description:
+    - If `true`, messages published with the same orderingKey in PubsubMessage will
+      be delivered to the subscribers in the order in which they are received by the
+      Pub/Sub system. Otherwise, they may be delivered in any order.
+    required: false
+    type: bool
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -474,6 +481,13 @@ deadLetterPolicy:
       - If this parameter is 0, a default value of 5 is used.
       returned: success
       type: int
+enableMessageOrdering:
+  description:
+  - If `true`, messages published with the same orderingKey in PubsubMessage will
+    be delivered to the subscribers in the order in which they are received by the
+    Pub/Sub system. Otherwise, they may be delivered in any order.
+  returned: success
+  type: bool
 '''
 
 ################################################################################
@@ -519,6 +533,7 @@ def main():
             expiration_policy=dict(type='dict', options=dict(ttl=dict(required=True, type='str'))),
             filter=dict(type='str'),
             dead_letter_policy=dict(type='dict', options=dict(dead_letter_topic=dict(type='str'), max_delivery_attempts=dict(type='int'))),
+            enable_message_ordering=dict(type='bool'),
         )
     )
 
@@ -581,6 +596,8 @@ def updateMask(request, response):
         update_mask.append('expirationPolicy')
     if request.get('deadLetterPolicy') != response.get('deadLetterPolicy'):
         update_mask.append('deadLetterPolicy')
+    if request.get('enableMessageOrdering') != response.get('enableMessageOrdering'):
+        update_mask.append('enableMessageOrdering')
     return ','.join(update_mask)
 
 
@@ -601,6 +618,7 @@ def resource_to_request(module):
         u'expirationPolicy': SubscriptionExpirationpolicy(module.params.get('expiration_policy', {}), module).to_request(),
         u'filter': module.params.get('filter'),
         u'deadLetterPolicy': SubscriptionDeadletterpolicy(module.params.get('dead_letter_policy', {}), module).to_request(),
+        u'enableMessageOrdering': module.params.get('enable_message_ordering'),
     }
     return_vals = {}
     for k, v in request.items():
@@ -676,6 +694,7 @@ def response_to_hash(module, response):
         u'expirationPolicy': SubscriptionExpirationpolicy(response.get(u'expirationPolicy', {}), module).from_response(),
         u'filter': module.params.get('filter'),
         u'deadLetterPolicy': SubscriptionDeadletterpolicy(response.get(u'deadLetterPolicy', {}), module).from_response(),
+        u'enableMessageOrdering': response.get(u'enableMessageOrdering'),
     }
 
 

--- a/plugins/modules/gcp_pubsub_subscription.py
+++ b/plugins/modules/gcp_pubsub_subscription.py
@@ -184,6 +184,14 @@ options:
         - Example - "3.5s".
         required: true
         type: str
+  filter:
+    description:
+    - The subscription only delivers the messages that match the filter. Pub/Sub automatically
+      acknowledges the messages that don't match the filter. You can filter messages
+      by their attributes. The maximum length of a filter is 256 bytes. After creating
+      the subscription, you can't modify the filter.
+    required: false
+    type: str
   dead_letter_policy:
     description:
     - A policy that specifies the conditions for dead lettering messages in this subscription.
@@ -423,6 +431,14 @@ expirationPolicy:
       - Example - "3.5s".
       returned: success
       type: str
+filter:
+  description:
+  - The subscription only delivers the messages that match the filter. Pub/Sub automatically
+    acknowledges the messages that don't match the filter. You can filter messages
+    by their attributes. The maximum length of a filter is 256 bytes. After creating
+    the subscription, you can't modify the filter.
+  returned: success
+  type: str
 deadLetterPolicy:
   description:
   - A policy that specifies the conditions for dead lettering messages in this subscription.
@@ -501,6 +517,7 @@ def main():
             message_retention_duration=dict(default='604800s', type='str'),
             retain_acked_messages=dict(type='bool'),
             expiration_policy=dict(type='dict', options=dict(ttl=dict(required=True, type='str'))),
+            filter=dict(type='str'),
             dead_letter_policy=dict(type='dict', options=dict(dead_letter_topic=dict(type='str'), max_delivery_attempts=dict(type='int'))),
         )
     )
@@ -582,6 +599,7 @@ def resource_to_request(module):
         u'messageRetentionDuration': module.params.get('message_retention_duration'),
         u'retainAckedMessages': module.params.get('retain_acked_messages'),
         u'expirationPolicy': SubscriptionExpirationpolicy(module.params.get('expiration_policy', {}), module).to_request(),
+        u'filter': module.params.get('filter'),
         u'deadLetterPolicy': SubscriptionDeadletterpolicy(module.params.get('dead_letter_policy', {}), module).to_request(),
     }
     return_vals = {}
@@ -656,6 +674,7 @@ def response_to_hash(module, response):
         u'messageRetentionDuration': response.get(u'messageRetentionDuration'),
         u'retainAckedMessages': response.get(u'retainAckedMessages'),
         u'expirationPolicy': SubscriptionExpirationpolicy(response.get(u'expirationPolicy', {}), module).from_response(),
+        u'filter': module.params.get('filter'),
         u'deadLetterPolicy': SubscriptionDeadletterpolicy(response.get(u'deadLetterPolicy', {}), module).from_response(),
     }
 

--- a/plugins/modules/gcp_pubsub_subscription.py
+++ b/plugins/modules/gcp_pubsub_subscription.py
@@ -34,7 +34,6 @@ description:
 - A named resource representing the stream of messages from a single, specific topic,
   to be delivered to the subscribing application.
 short_description: Creates a GCP Subscription
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -69,7 +68,6 @@ options:
     - A set of key/value label pairs to assign to this Subscription.
     required: false
     type: dict
-    version_added: '2.8'
   push_config:
     description:
     - If push delivery is used with this subscription, this field is used to configure
@@ -84,7 +82,6 @@ options:
           header in the HTTP request for every pushed message.
         required: false
         type: dict
-        version_added: '2.10'
         suboptions:
           service_account_email:
             description:
@@ -160,7 +157,6 @@ options:
     required: false
     default: 604800s
     type: str
-    version_added: '2.8'
   retain_acked_messages:
     description:
     - Indicates whether to retain acknowledged messages. If `true`, then messages
@@ -168,7 +164,6 @@ options:
       until they fall out of the messageRetentionDuration window.
     required: false
     type: bool
-    version_added: '2.8'
   expiration_policy:
     description:
     - A policy that specifies the conditions for this subscription's expiration.
@@ -179,7 +174,6 @@ options:
       value for expirationPolicy.ttl is 1 day.
     required: false
     type: dict
-    version_added: '2.9'
     suboptions:
       ttl:
         description:
@@ -199,13 +193,12 @@ options:
       must have permission to Acknowledge() messages on this subscription.
     required: false
     type: dict
-    version_added: '2.10'
     suboptions:
       dead_letter_topic:
         description:
         - The name of the topic to which dead letter messages should be published.
         - Format is `projects/{project}/topics/{topic}`.
-        - The Cloud Pub/Sub service\naccount associated with the enclosing subscription's
+        - The Cloud Pub/Sub service account associated with the enclosing subscription's
           parent project (i.e., service-{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com)
           must have permission to Publish() to this topic.
         - The operation will fail if the topic does not exist.
@@ -257,6 +250,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -443,7 +437,7 @@ deadLetterPolicy:
       description:
       - The name of the topic to which dead letter messages should be published.
       - Format is `projects/{project}/topics/{topic}`.
-      - The Cloud Pub/Sub service\naccount associated with the enclosing subscription's
+      - The Cloud Pub/Sub service account associated with the enclosing subscription's
         parent project (i.e., service-{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com)
         must have permission to Publish() to this topic.
       - The operation will fail if the topic does not exist.

--- a/plugins/modules/gcp_pubsub_subscription_info.py
+++ b/plugins/modules/gcp_pubsub_subscription_info.py
@@ -279,6 +279,32 @@ resources:
           - If this parameter is 0, a default value of 5 is used.
           returned: success
           type: int
+    retryPolicy:
+      description:
+      - A policy that specifies how Pub/Sub retries message delivery for this subscription.
+      - If not set, the default retry policy is applied. This generally implies that
+        messages will be retried as soon as possible for healthy subscribers. RetryPolicy
+        will be triggered on NACKs or acknowledgement deadline exceeded events for
+        a given message .
+      returned: success
+      type: complex
+      contains:
+        minimumBackoff:
+          description:
+          - The minimum delay between consecutive deliveries of a given message. Value
+            should be between 0 and 600 seconds. Defaults to 10 seconds.
+          - 'A duration in seconds with up to nine fractional digits, terminated by
+            ''s''. Example: "3.5s".'
+          returned: success
+          type: str
+        maximumBackoff:
+          description:
+          - 'The maximum delay between consecutive deliveries of a given message.
+            Value should be between 0 and 600 seconds. Defaults to 600 seconds. A
+            duration in seconds with up to nine fractional digits, terminated by ''s''.
+            Example: "3.5s".'
+          returned: success
+          type: str
     enableMessageOrdering:
       description:
       - If `true`, messages published with the same orderingKey in PubsubMessage will

--- a/plugins/modules/gcp_pubsub_subscription_info.py
+++ b/plugins/modules/gcp_pubsub_subscription_info.py
@@ -236,6 +236,14 @@ resources:
           - Example - "3.5s".
           returned: success
           type: str
+    filter:
+      description:
+      - The subscription only delivers the messages that match the filter. Pub/Sub
+        automatically acknowledges the messages that don't match the filter. You can
+        filter messages by their attributes. The maximum length of a filter is 256
+        bytes. After creating the subscription, you can't modify the filter.
+      returned: success
+      type: str
     deadLetterPolicy:
       description:
       - A policy that specifies the conditions for dead lettering messages in this

--- a/plugins/modules/gcp_pubsub_subscription_info.py
+++ b/plugins/modules/gcp_pubsub_subscription_info.py
@@ -33,7 +33,6 @@ module: gcp_pubsub_subscription_info
 description:
 - Gather info for GCP Subscription
 short_description: Gather info for GCP Subscription
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -71,6 +70,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -250,7 +250,7 @@ resources:
           description:
           - The name of the topic to which dead letter messages should be published.
           - Format is `projects/{project}/topics/{topic}`.
-          - The Cloud Pub/Sub service\naccount associated with the enclosing subscription's
+          - The Cloud Pub/Sub service account associated with the enclosing subscription's
             parent project (i.e., service-{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com)
             must have permission to Publish() to this topic.
           - The operation will fail if the topic does not exist.
@@ -276,7 +276,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_pubsub_subscription_info.py
+++ b/plugins/modules/gcp_pubsub_subscription_info.py
@@ -279,6 +279,13 @@ resources:
           - If this parameter is 0, a default value of 5 is used.
           returned: success
           type: int
+    enableMessageOrdering:
+      description:
+      - If `true`, messages published with the same orderingKey in PubsubMessage will
+        be delivered to the subscribers in the order in which they are received by
+        the Pub/Sub system. Otherwise, they may be delivered in any order.
+      returned: success
+      type: bool
 '''
 
 ################################################################################

--- a/plugins/modules/gcp_pubsub_topic.py
+++ b/plugins/modules/gcp_pubsub_topic.py
@@ -33,7 +33,6 @@ module: gcp_pubsub_topic
 description:
 - A named resource to which messages are sent by publishers.
 short_description: Creates a GCP Topic
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -61,13 +60,11 @@ options:
     - The expected format is `projects/*/locations/*/keyRings/*/cryptoKeys/*` .
     required: false
     type: str
-    version_added: '2.9'
   labels:
     description:
     - A set of key/value label pairs to assign to this Topic.
     required: false
     type: dict
-    version_added: '2.8'
   message_storage_policy:
     description:
     - Policy constraining the set of Google Cloud Platform regions where messages
@@ -75,7 +72,6 @@ options:
       in effect.
     required: false
     type: dict
-    version_added: '2.9'
     suboptions:
       allowed_persistence_regions:
         description:
@@ -118,6 +114,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_pubsub_topic_info.py
+++ b/plugins/modules/gcp_pubsub_topic_info.py
@@ -33,7 +33,6 @@ module: gcp_pubsub_topic_info
 description:
 - Gather info for GCP Topic
 short_description: Gather info for GCP Topic
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -71,6 +70,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -145,7 +145,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_redis_instance.py
+++ b/plugins/modules/gcp_redis_instance.py
@@ -33,7 +33,6 @@ module: gcp_redis_instance
 description:
 - A Google Cloud Redis instance.
 short_description: Creates a GCP Instance
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -68,7 +67,6 @@ options:
     required: false
     default: DIRECT_PEERING
     type: str
-    version_added: '2.10'
   display_name:
     description:
     - An arbitrary and optional user-provided name for the instance.
@@ -165,6 +163,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_redis_instance.py
+++ b/plugins/modules/gcp_redis_instance.py
@@ -513,7 +513,7 @@ def response_to_hash(module, response):
         u'authorizedNetwork': module.params.get('authorized_network'),
         u'connectMode': module.params.get('connect_mode'),
         u'createTime': response.get(u'createTime'),
-        u'currentLocationId': module.params.get('current_location_id'),
+        u'currentLocationId': response.get(u'currentLocationId'),
         u'displayName': response.get(u'displayName'),
         u'host': response.get(u'host'),
         u'labels': response.get(u'labels'),

--- a/plugins/modules/gcp_redis_instance_info.py
+++ b/plugins/modules/gcp_redis_instance_info.py
@@ -33,7 +33,6 @@ module: gcp_redis_instance_info
 description:
 - Gather info for GCP Instance
 short_description: Gather info for GCP Instance
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -76,6 +75,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -230,7 +230,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_resourcemanager_project.py
+++ b/plugins/modules/gcp_resourcemanager_project.py
@@ -34,7 +34,6 @@ description:
 - Represents a GCP Project. A project is a container for ACLs, APIs, App Engine Apps,
   VMs, and other Google Cloud Platform resources.
 short_description: Creates a GCP Project
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -122,6 +121,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_resourcemanager_project_info.py
+++ b/plugins/modules/gcp_resourcemanager_project_info.py
@@ -33,7 +33,6 @@ module: gcp_resourcemanager_project_info
 description:
 - Gather info for GCP Project
 short_description: Gather info for GCP Project
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -71,6 +70,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -166,7 +166,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_runtimeconfig_config.py
+++ b/plugins/modules/gcp_runtimeconfig_config.py
@@ -34,7 +34,6 @@ description:
 - A RuntimeConfig resource is the primary resource in the Cloud RuntimeConfig service.
 - A RuntimeConfig resource consists of metadata and a hierarchy of variables.
 short_description: Creates a GCP Config
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -90,6 +89,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_runtimeconfig_config_info.py
+++ b/plugins/modules/gcp_runtimeconfig_config_info.py
@@ -33,7 +33,6 @@ module: gcp_runtimeconfig_config_info
 description:
 - Gather info for GCP Config
 short_description: Gather info for GCP Config
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -71,6 +70,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -119,7 +119,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_runtimeconfig_variable.py
+++ b/plugins/modules/gcp_runtimeconfig_variable.py
@@ -33,7 +33,6 @@ module: gcp_runtimeconfig_variable
 description:
 - Describes a single variable within a runtime config resource.
 short_description: Creates a GCP Variable
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -99,6 +98,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_runtimeconfig_variable_info.py
+++ b/plugins/modules/gcp_runtimeconfig_variable_info.py
@@ -33,7 +33,6 @@ module: gcp_runtimeconfig_variable_info
 description:
 - Gather info for GCP Variable
 short_description: Gather info for GCP Variable
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -76,6 +75,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -135,7 +135,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_serviceusage_service.py
+++ b/plugins/modules/gcp_serviceusage_service.py
@@ -33,7 +33,6 @@ module: gcp_serviceusage_service
 description:
 - A service that is available for use .
 short_description: Creates a GCP Service
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -90,6 +89,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_serviceusage_service_info.py
+++ b/plugins/modules/gcp_serviceusage_service_info.py
@@ -33,7 +33,6 @@ module: gcp_serviceusage_service_info
 description:
 - Gather info for GCP Service
 short_description: Gather info for GCP Service
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -71,6 +70,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -162,7 +162,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_sourcerepo_repository.py
+++ b/plugins/modules/gcp_sourcerepo_repository.py
@@ -33,7 +33,6 @@ module: gcp_sourcerepo_repository
 description:
 - A repository (or repo) is a Git repository storing versioned source content.
 short_description: Creates a GCP Repository
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -86,6 +85,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_sourcerepo_repository_info.py
+++ b/plugins/modules/gcp_sourcerepo_repository_info.py
@@ -33,7 +33,6 @@ module: gcp_sourcerepo_repository_info
 description:
 - Gather info for GCP Repository
 short_description: Gather info for GCP Repository
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -71,6 +70,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -126,7 +126,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_spanner_database.py
+++ b/plugins/modules/gcp_spanner_database.py
@@ -33,7 +33,6 @@ module: gcp_spanner_database
 description:
 - A Cloud Spanner Database which is hosted on a Spanner instance.
 short_description: Creates a GCP Database
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -104,6 +103,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_spanner_database_info.py
+++ b/plugins/modules/gcp_spanner_database_info.py
@@ -33,7 +33,6 @@ module: gcp_spanner_database_info
 description:
 - Gather info for GCP Database
 short_description: Gather info for GCP Database
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -81,6 +80,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -139,7 +139,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest, replace_resource_dict
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest, replace_resource_dict
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_spanner_instance.py
+++ b/plugins/modules/gcp_spanner_instance.py
@@ -33,7 +33,6 @@ module: gcp_spanner_instance
 description:
 - An isolated set of Cloud Spanner resources on which databases can be hosted.
 short_description: Creates a GCP Instance
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -113,6 +112,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_spanner_instance_info.py
+++ b/plugins/modules/gcp_spanner_instance_info.py
@@ -33,7 +33,6 @@ module: gcp_spanner_instance_info
 description:
 - Gather info for GCP Instance
 short_description: Gather info for GCP Instance
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -71,6 +70,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -142,7 +142,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_sql_database.py
+++ b/plugins/modules/gcp_sql_database.py
@@ -33,7 +33,6 @@ module: gcp_sql_database
 description:
 - Represents a SQL database inside the Cloud SQL instance, hosted in Google's cloud.
 short_description: Creates a GCP Database
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -106,6 +105,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_sql_database_info.py
+++ b/plugins/modules/gcp_sql_database_info.py
@@ -33,7 +33,6 @@ module: gcp_sql_database_info
 description:
 - Gather info for GCP Database
 short_description: Gather info for GCP Database
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -76,6 +75,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -142,7 +142,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_sql_instance.py
+++ b/plugins/modules/gcp_sql_instance.py
@@ -35,7 +35,6 @@ description:
   Google's cloud. The Instances resource provides methods for common configuration
   and management tasks.
 short_description: Creates a GCP Instance
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -229,7 +228,6 @@ options:
         elements: dict
         required: false
         type: list
-        version_added: '2.9'
         suboptions:
           name:
             description:
@@ -331,13 +329,11 @@ options:
           single key value pair.
         required: false
         type: dict
-        version_added: '2.10'
   disk_encryption_configuration:
     description:
     - Disk encyption settings.
     required: false
     type: dict
-    version_added: '2.10'
     suboptions:
       kms_key_name:
         description:
@@ -349,7 +345,6 @@ options:
     - Disk encyption status.
     required: false
     type: dict
-    version_added: '2.10'
     suboptions:
       kms_key_version_name:
         description:
@@ -387,6 +382,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_sql_instance_info.py
+++ b/plugins/modules/gcp_sql_instance_info.py
@@ -33,7 +33,6 @@ module: gcp_sql_instance_info
 description:
 - Gather info for GCP Instance
 short_description: Gather info for GCP Instance
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -71,6 +70,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -497,7 +497,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_sql_ssl_cert.py
+++ b/plugins/modules/gcp_sql_ssl_cert.py
@@ -36,7 +36,6 @@ description:
   Client Key can be downloaded only when the SSL certificate is created with the insert
   method.
 short_description: Creates a GCP SslCert
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -122,6 +121,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_sql_user.py
+++ b/plugins/modules/gcp_sql_user.py
@@ -33,7 +33,6 @@ module: gcp_sql_user
 description:
 - The Users resource represents a database user in a Cloud SQL instance.
 short_description: Creates a GCP User
-version_added: '2.7'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -106,6 +105,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_sql_user_info.py
+++ b/plugins/modules/gcp_sql_user_info.py
@@ -33,7 +33,6 @@ module: gcp_sql_user_info
 description:
 - Gather info for GCP User
 short_description: Gather info for GCP User
-version_added: '2.8'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -81,6 +80,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -142,7 +142,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest, replace_resource_dict
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest, replace_resource_dict
 import json
 
 ################################################################################

--- a/plugins/modules/gcp_storage_bucket.py
+++ b/plugins/modules/gcp_storage_bucket.py
@@ -249,7 +249,7 @@ options:
                 description:
                 - Objects having any of the storage classes specified by this condition
                   will be matched. Values include MULTI_REGIONAL, REGIONAL, NEARLINE,
-                  COLDLINE, STANDARD, and DURABLE_REDUCED_AVAILABILITY.
+                  COLDLINE, ARCHIVE, STANDARD, and DURABLE_REDUCED_AVAILABILITY.
                 elements: str
                 required: false
                 type: list
@@ -310,11 +310,11 @@ options:
     - The bucket's default storage class, used whenever no storageClass is specified
       for a newly-created object. This defines how objects in the bucket are stored
       and determines the SLA and the cost of storage.
-    - Values include MULTI_REGIONAL, REGIONAL, STANDARD, NEARLINE, COLDLINE, and DURABLE_REDUCED_AVAILABILITY.
-      If this value is not specified when the bucket is created, it will default to
-      STANDARD. For more information, see storage classes.
+    - Values include MULTI_REGIONAL, REGIONAL, STANDARD, NEARLINE, COLDLINE, ARCHIVE,
+      and DURABLE_REDUCED_AVAILABILITY. If this value is not specified when the bucket
+      is created, it will default to STANDARD. For more information, see storage classes.
     - 'Some valid choices include: "MULTI_REGIONAL", "REGIONAL", "STANDARD", "NEARLINE",
-      "COLDLINE", "DURABLE_REDUCED_AVAILABILITY"'
+      "COLDLINE", "ARCHIVE", "DURABLE_REDUCED_AVAILABILITY"'
     required: false
     type: str
   versioning:
@@ -659,7 +659,7 @@ lifecycle:
               description:
               - Objects having any of the storage classes specified by this condition
                 will be matched. Values include MULTI_REGIONAL, REGIONAL, NEARLINE,
-                COLDLINE, STANDARD, and DURABLE_REDUCED_AVAILABILITY.
+                COLDLINE, ARCHIVE, STANDARD, and DURABLE_REDUCED_AVAILABILITY.
               returned: success
               type: list
             numNewerVersions:
@@ -729,9 +729,9 @@ storageClass:
   - The bucket's default storage class, used whenever no storageClass is specified
     for a newly-created object. This defines how objects in the bucket are stored
     and determines the SLA and the cost of storage.
-  - Values include MULTI_REGIONAL, REGIONAL, STANDARD, NEARLINE, COLDLINE, and DURABLE_REDUCED_AVAILABILITY.
-    If this value is not specified when the bucket is created, it will default to
-    STANDARD. For more information, see storage classes.
+  - Values include MULTI_REGIONAL, REGIONAL, STANDARD, NEARLINE, COLDLINE, ARCHIVE,
+    and DURABLE_REDUCED_AVAILABILITY. If this value is not specified when the bucket
+    is created, it will default to STANDARD. For more information, see storage classes.
   returned: success
   type: str
 timeCreated:

--- a/plugins/modules/gcp_storage_bucket.py
+++ b/plugins/modules/gcp_storage_bucket.py
@@ -977,11 +977,11 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 
 def self_link(module):
-    return "https://www.googleapis.com/storage/v1/b/{name}?projection=full".format(**module.params)
+    return "https://storage.googleapis.com/storage/v1/b/{name}?projection=full".format(**module.params)
 
 
 def collection(module):
-    return "https://www.googleapis.com/storage/v1/b?project={project}".format(**module.params)
+    return "https://storage.googleapis.com/storage/v1/b?project={project}".format(**module.params)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):

--- a/plugins/modules/gcp_storage_bucket.py
+++ b/plugins/modules/gcp_storage_bucket.py
@@ -38,7 +38,6 @@ description:
   manipulation of an existing bucket's access controls.
 - A bucket is always owned by the project team owners group.
 short_description: Creates a GCP Bucket
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -150,14 +149,12 @@ options:
       to the bucket.
     required: false
     type: bool
-    version_added: '2.10'
   default_object_acl:
     description:
     - Default access controls to apply to new objects when no ACL is provided.
     elements: dict
     required: false
     type: list
-    version_added: '2.7'
     suboptions:
       bucket:
         description:
@@ -359,7 +356,6 @@ options:
     - Labels applied to this bucket. A list of key->value pairs.
     required: false
     type: dict
-    version_added: '2.10'
   project:
     description:
     - The Google Cloud Platform project to use.
@@ -408,6 +404,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_storage_bucket_access_control.py
+++ b/plugins/modules/gcp_storage_bucket_access_control.py
@@ -314,12 +314,12 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 def self_link(module):
     res = {'bucket': replace_resource_dict(module.params['bucket'], 'name'), 'entity': module.params['entity']}
-    return "https://www.googleapis.com/storage/v1/b/{bucket}/acl/{entity}".format(**res)
+    return "https://storage.googleapis.com/storage/v1/b/{bucket}/acl/{entity}".format(**res)
 
 
 def collection(module):
     res = {'bucket': replace_resource_dict(module.params['bucket'], 'name')}
-    return "https://www.googleapis.com/storage/v1/b/{bucket}/acl".format(**res)
+    return "https://storage.googleapis.com/storage/v1/b/{bucket}/acl".format(**res)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):

--- a/plugins/modules/gcp_storage_bucket_access_control.py
+++ b/plugins/modules/gcp_storage_bucket_access_control.py
@@ -42,7 +42,6 @@ description:
   see Access Control, with the caveat that this API uses READER, WRITER, and OWNER
   instead of READ, WRITE, and FULL_CONTROL.'
 short_description: Creates a GCP BucketAccessControl
-version_added: '2.6'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -114,6 +113,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_storage_default_object_acl.py
+++ b/plugins/modules/gcp_storage_default_object_acl.py
@@ -330,12 +330,12 @@ def fetch_resource(module, link, kind, allow_not_found=True):
 
 def self_link(module):
     res = {'bucket': replace_resource_dict(module.params['bucket'], 'name'), 'entity': module.params['entity']}
-    return "https://www.googleapis.com/storage/v1/b/{bucket}/defaultObjectAcl/{entity}".format(**res)
+    return "https://storage.googleapis.com/storage/v1/b/{bucket}/defaultObjectAcl/{entity}".format(**res)
 
 
 def collection(module):
     res = {'bucket': replace_resource_dict(module.params['bucket'], 'name')}
-    return "https://www.googleapis.com/storage/v1/b/{bucket}/defaultObjectAcl".format(**res)
+    return "https://storage.googleapis.com/storage/v1/b/{bucket}/defaultObjectAcl".format(**res)
 
 
 def return_if_object(module, response, kind, allow_not_found=False):

--- a/plugins/modules/gcp_storage_default_object_acl.py
+++ b/plugins/modules/gcp_storage_default_object_acl.py
@@ -43,7 +43,6 @@ description:
 - For more information, see Access Control, with the caveat that this API uses READER
   and OWNER instead of READ and FULL_CONTROL.
 short_description: Creates a GCP DefaultObjectACL
-version_added: '2.10'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -118,6 +117,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_tpu_node.py
+++ b/plugins/modules/gcp_tpu_node.py
@@ -33,7 +33,6 @@ module: gcp_tpu_node
 description:
 - A Cloud TPU instance.
 short_description: Creates a GCP Node
-version_added: '2.9'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -139,6 +138,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.

--- a/plugins/modules/gcp_tpu_node_info.py
+++ b/plugins/modules/gcp_tpu_node_info.py
@@ -33,7 +33,6 @@ module: gcp_tpu_node_info
 description:
 - Gather info for GCP Node
 short_description: Gather info for GCP Node
-version_added: '2.9'
 author: Google Inc. (@googlecloudplatform)
 requirements:
 - python >= 2.6
@@ -76,6 +75,7 @@ options:
     description:
     - Array of scopes to be used
     type: list
+    elements: str
   env_type:
     description:
     - Specifies which Ansible environment you're running this module within.
@@ -200,7 +200,7 @@ resources:
 ################################################################################
 # Imports
 ################################################################################
-from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
 import json
 
 ################################################################################


### PR DESCRIPTION
This commit solve a problem that whe have been facing when trying to create a disk from a snashot. 

gcp_compute_module allow field sourceSnapshot but it's not sending to gcp api.

Now you can pass selflink or gcp_compute_snapshot object and it will be sended correctly to gcp api.

##### SUMMARY
Including sourceSnapshot field to the request and defining if selflink our gcp_compute_snapshot object.

Fixes old repo issue. 
https://github.com/ansible/ansible/issues/61635

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
gcp_compute_disk.py

##### ADDITIONAL INFORMATION
gcp_compute_disk module is not able to send sourceSnapshot to the gcp api, so it's impossible to create a disk from a snapshot created before.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```There wasn't an error, the module created a empt disk without error when trying to create a disk from snapshot.

```
