### PR TITLE
Add example of creating a group from a jinja2 conditional

### DIFF
--- a/plugins/inventory/gcp_compute.py
+++ b/plugins/inventory/gcp_compute.py
@@ -131,6 +131,9 @@ keyed_groups:
   # Create groups from GCE labels
   - prefix: gcp
     key: labels
+groups:
+  # Create groups from Jinja2 conditionals (f.e. instance name with a regex)
+  group_from_jinja_expression: "name | regex_search('-([a-z]+-[0-9]{2}[a-z]?)$')"
 hostnames:
   # List host by name instead of the default public ip
   - name


### PR DESCRIPTION


##### SUMMARY
Example of use of `groups` using a jinja2 expression.
This example uses instance names with a regex to build an inventory
group.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/inventory/gcp_compute

##### ADDITIONAL INFORMATION
N/A
