### PR TITLE
Set fingerprint when updating backend service

### DIFF
--- a/plugins/modules/gcp_compute_backend_service.py
+++ b/plugins/modules/gcp_compute_backend_service.py
@@ -1427,7 +1427,11 @@ def create(module, link, kind):
 def update(module, link, kind, fetch):
     update_fields(module, resource_to_request(module), response_to_hash(module, fetch))
     auth = GcpSession(module, 'compute')
-    return wait_for_operation(module, auth.put(link, resource_to_request(module)))
+
+    request = resource_to_request(module)
+    request.update({'fingerprint': fetch.get('fingerprint')})
+
+    return wait_for_operation(module, auth.put(link, request))
 
 
 def update_fields(module, request, response):

--- a/plugins/modules/gcp_compute_instance_template.py
+++ b/plugins/modules/gcp_compute_instance_template.py
@@ -1201,6 +1201,7 @@ def response_to_hash(module, response):
 
 
 def disk_type_selflink(name, params):
+    return name
     if name is None:
         return
     url = r"https://compute.googleapis.com/compute/v1/projects/.*/zones/.*/diskTypes/.*"

--- a/plugins/modules/gcp_compute_region_autoscaler.py
+++ b/plugins/modules/gcp_compute_region_autoscaler.py
@@ -506,7 +506,8 @@ def main():
     if fetch:
         if state == 'present':
             if is_different(module, fetch):
-                update(module, self_link(module), kind)
+                link="https://compute.googleapis.com/compute/v1/projects/{project}/regions/{region}/autoscalers?autoscaler={name}".format(**module.params)
+                update(module, link, kind)
                 fetch = fetch_resource(module, self_link(module), kind)
                 changed = True
         else:

--- a/plugins/modules/gcp_compute_region_instance_group_manager.py
+++ b/plugins/modules/gcp_compute_region_instance_group_manager.py
@@ -446,7 +446,7 @@ def main():
     if fetch:
         if state == 'present':
             if is_different(module, fetch):
-                update(module, self_link(module), kind)
+                update(module, self_link(module), kind, fetch)
                 fetch = fetch_resource(module, self_link(module), kind)
                 changed = True
         else:
@@ -470,9 +470,13 @@ def create(module, link, kind):
     return wait_for_operation(module, auth.post(link, resource_to_request(module)))
 
 
-def update(module, link, kind):
+def update(module, link, kind, fetch):
     auth = GcpSession(module, 'compute')
-    return wait_for_operation(module, auth.put(link, resource_to_request(module)))
+
+    request = resource_to_request(module)
+    request.update({'fingerprint': fetch.get('fingerprint')})
+
+    return wait_for_operation(module, auth.put(link, request))
 
 
 def delete(module, link, kind):


### PR DESCRIPTION
##### SUMMARY
According to the API documentation for [fingerprint](https://cloud.google.com/compute/docs/reference/rest/v1/backendServices)

> An up-to-date fingerprint must be provided in order to update the BackendService, otherwise the request will fail with error 412 conditionNotMet.

Fingerprint is never set by `gcp_compute_backend_service`, causing updates to a backend service to fail. This change updates the request with the fingerprint that was previously fetched for change detection.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gcp_compute_backend_service

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: update backend service                                                     
  register: service                                                                
  google.cloud.gcp_compute_backend_service:                                        
    name: backend-service                                                
    health_checks:                                                                 
    - "{{ healthcheck['resources'][0]['selfLink'] }}"                              
    state: present                                                                                      
    backends:                                                                      
      - group: "{{mig['resources'][0]['instanceGroup']}}"                                                                        
                                                                                   
    project: "{{project}}"                                                         
    auth_kind: serviceaccount                                                      
    service_account_contents: "{{service_account_contents | string}}"

Before Change:
TASK [update backend service] ******************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "GCP returned error: {'error': {'code': 400, 'message': \"Required field 'resource.fingerprint' not specified\", 'errors': [{'message': \"Required fiel
d 'resource.fingerprint' not specified\", 'domain': 'global', 'reason': 'required'}]}}"}

After Change:
TASK [update backend service] ******************
changed: [localhost]
```
