### PR TITLE
Updating gcp_storage_object module example

### DIFF
--- a/plugins/modules/gcp_storage_object.py
+++ b/plugins/modules/gcp_storage_object.py
@@ -96,7 +96,7 @@ options:
 """
 
 EXAMPLES = """
-- name: create a object
+- name: Download an object
   google.cloud.gcp_storage_object:
     action: download
     bucket: ansible-bucket
@@ -105,7 +105,6 @@ EXAMPLES = """
     project: test_project
     auth_kind: serviceaccount
     service_account_file: "/tmp/auth.pem"
-    state: present
 """
 
 RETURN = """


### PR DESCRIPTION
The example contained the non-existent "status" parameter which causes an error with the latest release.

##### SUMMARY

This PR updates the example provided in the documentation for the gcp_storage_object module. The parameter `status` does no longer exist and if used causes an error. 
Therefore it should also be removed from the example code.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
 `gcp_storage_object.py`

##### ADDITIONAL INFORMATION
Behaviour is unchanged.
