### PR TITLE
Fetch projects in folder based on projectID instead of name

### DIFF
--- a/plugins/inventory/gcp_compute.py
+++ b/plugins/inventory/gcp_compute.py
@@ -518,7 +518,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         if 'projects' in projects_response:
             for item in projects_response.get('projects'):
-                projects.append(item['name'])
+                projects.append(item['projectId'])
         return projects
 
     def parse(self, inventory, loader, path, cache=True):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
google.cloud.gcp_compute

##### ADDITIONAL INFORMATION
Fixes https://github.com/ansible-collections/google.cloud/issues/382
<!--- Paste verbatim command output below, e.g. before and after your change -->
Before
```
$ ansible-inventory --graph
[WARNING]:  * Failed to parse /home/kroukoz/inventory/gcp.yaml with
ansible_collections.google.cloud.plugins.inventory.gcp_compute plugin: [{'message': 'Compute Engine API has not
been used in project <redacted_wrong_project_id> before or it is disabled. Enable it by visiting
                                            self._project_disks[
https://console.developers.google.com/apis/api/compute.googleapis.com/overview?project=<redacted_wrong_project_id>  then retry. If
you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.',
'domain': 'usageLimits', 'reason': 'accessNotConfigured', 'extendedHelp':
'https://console.developers.google.com'}]
[WARNING]: Unable to parse /home/kroukoz/inventory/gcp.yaml as an inventory source
```

After
```
$ ansible-inventory --graph
@all:
  |--@ungrouped:
  |  |--instance-1

```

