### PR TITLE
Update repository URL in galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -50,7 +50,7 @@ tags:
 #dependencies: {}
 
 # The URL of the originating SCM repository
-repository: http://github.com/ansible/ansible_collections_google
+repository: https://github.com/ansible-collections/google.cloud
 
 # The URL to any online docs
 #documentation: http://docs.example.com


### PR DESCRIPTION
The previous URL properly redirects to the new one but let's put the updated one.