### PR TITLE
fix: fix finger print issue while updating gcp services

### DIFF
--- a/plugins/modules/gcp_compute_backend_service.py
+++ b/plugins/modules/gcp_compute_backend_service.py
@@ -1293,6 +1293,7 @@ def main():
         argument_spec=dict(
             state=dict(default='present', choices=['present', 'absent'], type='str'),
             affinity_cookie_ttl_sec=dict(type='int'),
+            fingerprint=dict(type='str'),
             backends=dict(
                 type='list',
                 elements='dict',
@@ -1402,6 +1403,7 @@ def main():
     changed = False
 
     if fetch:
+        module.params['fingerprint'] = fetch['fingerprint']
         if state == 'present':
             if is_different(module, fetch):
                 update(module, self_link(module), kind, fetch)
@@ -1476,6 +1478,7 @@ def resource_to_request(module):
         u'sessionAffinity': module.params.get('session_affinity'),
         u'timeoutSec': module.params.get('timeout_sec'),
         u'logConfig': BackendServiceLogconfig(module.params.get('log_config', {}), module).to_request(),
+        u'fingerprint': module.params.get('fingerprint')
     }
     return_vals = {}
     for k, v in request.items():

--- a/plugins/modules/gcp_compute_url_map.py
+++ b/plugins/modules/gcp_compute_url_map.py
@@ -4972,6 +4972,7 @@ def main():
             state=dict(default='present', choices=['present', 'absent'], type='str'),
             default_service=dict(type='dict'),
             description=dict(type='str'),
+            fingerprint=dict(type='str'),
             header_action=dict(
                 type='dict',
                 options=dict(
@@ -5486,11 +5487,11 @@ def main():
     changed = False
 
     if fetch:
+        module.params['fingerprint'] = fetch['fingerprint']
         if state == 'present':
-            if is_different(module, fetch):
-                update(module, self_link(module), kind)
-                fetch = fetch_resource(module, self_link(module), kind)
-                changed = True
+            update(module, self_link(module), kind)
+            fetch = fetch_resource(module, self_link(module), kind)
+            changed = True
         else:
             delete(module, self_link(module), kind)
             fetch = {}
@@ -5534,6 +5535,7 @@ def resource_to_request(module):
         u'tests': UrlMapTestsArray(module.params.get('tests', []), module).to_request(),
         u'defaultUrlRedirect': UrlMapDefaulturlredirect(module.params.get('default_url_redirect', {}), module).to_request(),
         u'defaultRouteAction': UrlMapDefaultrouteaction(module.params.get('default_route_action', {}), module).to_request(),
+        u'fingerprint': module.params.get('fingerprint')
     }
     return_vals = {}
     for k, v in request.items():


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
It was not allowing to update the url_map / backend_services because the `fingerprint` was ignored in the update request.
As a result, added fingerprint to the request if available in case of updating `gcp_compute_url_map` / `gcp_compute_backend_service`.

Also `is_different` function was always returning true in case of `gcp_compute_url_map`. So if the `fetch` value is returned it's okay to consider it as an updated service and make the necessary change.

Here is the testing video
https://www.loom.com/share/266971457b7f44c9ac2c190855528822

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes: https://github.com/ansible-collections/google.cloud/issues/342
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
* `gcp_compute_url_map`
* `gcp_compute_backend_service`

