### PR TITLE
fix 'str' object has no attribute 'get'

### DIFF
--- a/plugins/module_utils/gcp_utils.py
+++ b/plugins/module_utils/gcp_utils.py
@@ -394,7 +394,7 @@ class GcpRequest(object):
         diff = None
         # If a None is found, a difference does not exist.
         # Only differing values matter.
-        if not resp_value:
+        if not resp_value or resp_value == "None":
             return None
 
         # Can assume non-None types at this point.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The function _compare_value attempts to return if "resp_value" is not set.
The problem occurs when one of the functions sets the response value "None" as string, rather than pythonic None.
This is a fix to also exit this function on a "None" string response value.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
gcp_utils via gcp_compute_instance

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
When I rerun Ansible on already existing instances, it fails with the following error:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
    Traceback (most recent call last):
      File "/Users/zachzoref/.ansible/tmp/ansible-tmp-1619365490.386965-46982-80026062348664/AnsiballZ_gcp_compute_instance.py", line 102, in <module>
        _ansiballz_main()
      File "/Users/zachzoref/.ansible/tmp/ansible-tmp-1619365490.386965-46982-80026062348664/AnsiballZ_gcp_compute_instance.py", line 94, in _ansiballz_main
        invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
      File "/Users/zachzoref/.ansible/tmp/ansible-tmp-1619365490.386965-46982-80026062348664/AnsiballZ_gcp_compute_instance.py", line 40, in invoke_module
        runpy.run_module(mod_name='ansible_collections.google.cloud.plugins.modules.gcp_compute_instance', init_globals=None, run_name='__main__', alter_sys=True)
      File "/usr/local/Cellar/python@3.8/3.8.9/Frameworks/Python.framework/Versions/3.8/lib/python3.8/runpy.py", line 207, in run_module
        return _run_module_code(code, init_globals, run_name, mod_spec)
      File "/usr/local/Cellar/python@3.8/3.8.9/Frameworks/Python.framework/Versions/3.8/lib/python3.8/runpy.py", line 97, in _run_module_code
        _run_code(code, mod_globals, init_globals,
      File "/usr/local/Cellar/python@3.8/3.8.9/Frameworks/Python.framework/Versions/3.8/lib/python3.8/runpy.py", line 87, in _run_code
        exec(code, run_globals)
      File "/var/folders/l6/cngprrmd6xq_5l59qsclp_gc0000gn/T/ansible_google.cloud.gcp_compute_instance_payload_653gs0xl/ansible_google.cloud.gcp_compute_instance_payload.zip/ansible_collections/google/cloud/plugins/modules/gcp_compute_instance.py", line 1856, in <module>
      File "/var/folders/l6/cngprrmd6xq_5l59qsclp_gc0000gn/T/ansible_google.cloud.gcp_compute_instance_payload_653gs0xl/ansible_google.cloud.gcp_compute_instance_payload.zip/ansible_collections/google/cloud/plugins/modules/gcp_compute_instance.py", line 1163, in main
      File "/var/folders/l6/cngprrmd6xq_5l59qsclp_gc0000gn/T/ansible_google.cloud.gcp_compute_instance_payload_653gs0xl/ansible_google.cloud.gcp_compute_instance_payload.zip/ansible_collections/google/cloud/plugins/modules/gcp_compute_instance.py", line 1310, in is_different
      File "/var/folders/l6/cngprrmd6xq_5l59qsclp_gc0000gn/T/ansible_google.cloud.gcp_compute_instance_payload_653gs0xl/ansible_google.cloud.gcp_compute_instance_payload.zip/ansible_collections/google/cloud/plugins/module_utils/gcp_utils.py", line 340, in __ne__
      File "/var/folders/l6/cngprrmd6xq_5l59qsclp_gc0000gn/T/ansible_google.cloud.gcp_compute_instance_payload_653gs0xl/ansible_google.cloud.gcp_compute_instance_payload.zip/ansible_collections/google/cloud/plugins/module_utils/gcp_utils.py", line 337, in __eq__
      File "/var/folders/l6/cngprrmd6xq_5l59qsclp_gc0000gn/T/ansible_google.cloud.gcp_compute_instance_payload_653gs0xl/ansible_google.cloud.gcp_compute_instance_payload.zip/ansible_collections/google/cloud/plugins/module_utils/gcp_utils.py", line 346, in difference
      File "/var/folders/l6/cngprrmd6xq_5l59qsclp_gc0000gn/T/ansible_google.cloud.gcp_compute_instance_payload_653gs0xl/ansible_google.cloud.gcp_compute_instance_payload.zip/ansible_collections/google/cloud/plugins/module_utils/gcp_utils.py", line 409, in _compare_value
      File "/var/folders/l6/cngprrmd6xq_5l59qsclp_gc0000gn/T/ansible_google.cloud.gcp_compute_instance_payload_653gs0xl/ansible_google.cloud.gcp_compute_instance_payload.zip/ansible_collections/google/cloud/plugins/module_utils/gcp_utils.py", line 354, in _compare_dicts
      File "/var/folders/l6/cngprrmd6xq_5l59qsclp_gc0000gn/T/ansible_google.cloud.gcp_compute_instance_payload_653gs0xl/ansible_google.cloud.gcp_compute_instance_payload.zip/ansible_collections/google/cloud/plugins/module_utils/gcp_utils.py", line 407, in _compare_value
      File "/var/folders/l6/cngprrmd6xq_5l59qsclp_gc0000gn/T/ansible_google.cloud.gcp_compute_instance_payload_653gs0xl/ansible_google.cloud.gcp_compute_instance_payload.zip/ansible_collections/google/cloud/plugins/module_utils/gcp_utils.py", line 382, in _compare_lists
      File "/var/folders/l6/cngprrmd6xq_5l59qsclp_gc0000gn/T/ansible_google.cloud.gcp_compute_instance_payload_653gs0xl/ansible_google.cloud.gcp_compute_instance_payload.zip/ansible_collections/google/cloud/plugins/module_utils/gcp_utils.py", line 409, in _compare_value
      File "/var/folders/l6/cngprrmd6xq_5l59qsclp_gc0000gn/T/ansible_google.cloud.gcp_compute_instance_payload_653gs0xl/ansible_google.cloud.gcp_compute_instance_payload.zip/ansible_collections/google/cloud/plugins/module_utils/gcp_utils.py", line 353, in _compare_dicts
    AttributeError: 'str' object has no attribute 'get'
```
The version of the module is 1.0.2