### PR TITLE
fix documentation for correct work inventory plugin

### DIFF
--- a/plugins/inventory/gcp_compute.py
+++ b/plugins/inventory/gcp_compute.py
@@ -22,7 +22,7 @@ DOCUMENTATION = """
         plugin:
             description: token that ensures this is a source file for the 'gcp_compute' plugin.
             required: True
-            choices: ['gcp_compute']
+            choices: ['google.cloud.gcp_compute']
         zones:
           description: A list of regions in which to describe GCE instances.
                        If none provided, it defaults to all zones available to a given project.


### PR DESCRIPTION
##### SUMMARY
Bug on DOCUMENTATION  pluggin inventory gcp_compute

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
pluggin inventory gcp_compute

##### ADDITIONAL INFORMATION

if:
 plugin: google.cloud.gcp_compute
then
error
with ansible_collections.google.cloud.plugins.inventory.gcp_compute plugin: Invalid value
"google.cloud.gcp_compute" for configuration option "plugin_type: inventory plugin: ansible_collections.google.cloud.plugins.inventory.gcp_compute setting: plugin ", valid values are: ['gcp_compute']
if:
plugin: gcp_compute
error
with ansible_collections.google.cloud.plugins.inventory.gcp_compute plugin: Incorrect plugin name in file:
gcp_compute
fix DOCUMENTATION options plugin choices: ['google.cloud.gcp_compute']