### PR TITLE
Add inventory hostname label support

### DIFF
--- a/plugins/inventory/gcp_compute.py
+++ b/plugins/inventory/gcp_compute.py
@@ -45,7 +45,7 @@ DOCUMENTATION = """
         hostnames:
           description: A list of options that describe the ordering for which
               hostnames should be assigned. Currently supported hostnames are
-              'public_ip', 'private_ip', or 'name'.
+              'public_ip', 'private_ip', 'name' or 'labels.vm_name'.
           default: ['public_ip', 'private_ip', 'name']
           type: list
         auth_kind:
@@ -230,7 +230,9 @@ class GcpInstance(object):
         """
         for order in self.hostname_ordering:
             name = None
-            if order == "public_ip":
+            if order.startswith("labels."):
+                name = self.json[u"labels"].get(order[7:])
+            elif order == "public_ip":
                 name = self._get_publicip()
             elif order == "private_ip":
                 name = self._get_privateip()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #463 Add labels option to the hostname section of the gcp inventory 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gcp_compute

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
If the supplied label exists the inventory_hostname will be the label value. This feature is already available in the AWS and Azure inventory. This would lift the need to rename virtual machines. You can now rename the inventory name by changing a tag. The real VM name can be an ID while the user can interact with something more human-friendly.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
hostnames:
  - labels.vm_name
  - public_ip
  - private_ip
  - name
```
