### PR TITLE
Fix gcp_compute_snapshot module to work with customer-supplied encryption key

### DIFF
--- a/plugins/modules/gcp_compute_snapshot.py
+++ b/plugins/modules/gcp_compute_snapshot.py
@@ -456,6 +456,10 @@ def resource_to_request(module):
         u'name': module.params.get('name'),
         u'description': module.params.get('description'),
         u'storageLocations': module.params.get('storage_locations'),
+        u'sourceDiskEncryptionKey': SnapshotSourcediskencryptionkey(module.params.get('source_disk_encryption_key', {}),
+                                                                    module).to_request(),
+        u'snapshotEncryptionKey': SnapshotSnapshotencryptionkey(module.params.get('snapshot_encryption_key', {}),
+                                                                module).to_request(),
         u'labels': module.params.get('labels'),
     }
     return_vals = {}
@@ -534,6 +538,10 @@ def response_to_hash(module, response):
         u'description': module.params.get('description'),
         u'storageBytes': response.get(u'storageBytes'),
         u'storageLocations': response.get(u'storageLocations'),
+        u'sourceDiskEncryptionKey': SnapshotSourcediskencryptionkey(module.params.get('source_disk_encryption_key', {}),
+                                                                    module).from_response(),
+        u'snapshotEncryptionKey': SnapshotSnapshotencryptionkey(module.params.get('snapshot_encryption_key', {}),
+                                                                module).from_response(),
         u'licenses': response.get(u'licenses'),
         u'labels': response.get(u'labels'),
         u'labelFingerprint': response.get(u'labelFingerprint'),


### PR DESCRIPTION
##### SUMMARY
Fixes missing field for a customer-supplied encryption key which prevents this module from creating a snapshot

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Module gcp_compute_snapshot

##### ADDITIONAL INFORMATION
Before change:
```
TASK [gcp : create a snapshot] ***********************************************************************************************
Thursday 18 November 2021  12:23:39 -0500 (0:00:00.062)       0:00:13.518 *****
failed: [test-example-> 127.0.0.1] (item=test-example) => {"ansible_loop_var": "volume_create_item", "changed": false, "msg": "GCP returned error: {'error': {'code': 400, 'message': \"'projects/********/zones/********/disks/test-example' is protected with a customer supplied encryption key, but none was provided.\", 'errors': [{'message': \"'projects/********/zones/********/disks/test-example' is protected with a customer supplied encryption key, but none was provided.\", 'domain': 'global', 'reason': 'resourceIsEncryptedWithCustomerEncryptionKey'}]}}",}
```
After change:
```
TASK [gcpr : create a snapshot] ***********************************************************************************************
Thursday 18 November 2021  12:26:18 -0500 (0:00:00.066)       0:00:14.092 *****
changed: [test-example -> 127.0.0.1] => (item=test-example)
```