### PR TITLE
add ability to detect and update network tags.

### DIFF
--- a/plugins/modules/gcp_compute_instance.py
+++ b/plugins/modules/gcp_compute_instance.py
@@ -1229,7 +1229,16 @@ def update_fields(module, request, response):
         machine_type_update(module, request, response)
     if response.get('shieldedInstanceConfig') != request.get('shieldedInstanceConfig'):
         shielded_instance_config_update(module, request, response)
+    if response.get("tags") != request.get("tags"):
+        tag_fingerprint_update(module,request,response)
 
+
+def tag_fingerprint_update(module, request, response):
+    auth = GcpSession(module, 'compute')
+    auth.post(
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/zones/{zone}/instances/{name}/setTags"]).format(**module.params),
+        {u'fingerprint': response.get('tags',{}).get('fingerprint'), u'items': module.params.get('tags', {}).get('items')},
+    )
 
 def label_fingerprint_update(module, request, response):
     auth = GcpSession(module, 'compute')

--- a/plugins/modules/gcp_compute_instance.py
+++ b/plugins/modules/gcp_compute_instance.py
@@ -1233,11 +1233,16 @@ def update_fields(module, request, response):
         tag_fingerprint_update(module,request,response)
 
 
+
+
 def tag_fingerprint_update(module, request, response):
     auth = GcpSession(module, 'compute')
+    if not module.params.get('tags'):
+        module.params['tags'] = {}
+    module.params['tags']['fingerprint'] = response.get('tags', {}).get('fingerprint')
     auth.post(
         ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/zones/{zone}/instances/{name}/setTags"]).format(**module.params),
-        {u'fingerprint': response.get('tags',{}).get('fingerprint'), u'items': module.params.get('tags', {}).get('items')},
+        InstanceTags(module.params.get('tags', {}), module).to_request(),
     )
 
 def label_fingerprint_update(module, request, response):


### PR DESCRIPTION
##### SUMMARY
When doing infrastructure as code it is expected that changes to code base will be reflected in the cloud platform. In this scenario changes to tags in the code base did not make its way to the cloud platform. This change rectifies this and follows the same principals as labels. 

<!--- Describe the change below, including rationale and design decisions -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
gcp_compute_instance

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Tags are currently created  on instance instantiation, this fix allows network tags to be updated using gitops methodologies. For example, down the road if network tags need to be added are removed they can be done so through code. 

Testing Scenario:

**Existing Instance with no network tags.** 

1. Define Tags
2. Ensure Tags are set properly

**Existing Instance with network tags.**
1. Remove tags from module parameters
2. Ensure Tags are removed

**New Instance**
1. Create New Instance
2. Ensure Tags are set as expected.

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1. Create Instance with No Tags
2. Update Tags in Code
3. Observe Tags did not change

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Before:
  "tags": {
      "fingerprint": "42WmSpB8rSM="
  },

After:        
"tags": {
            "fingerprint": "s78FYhaXW7M=",
            "items": [
                "vpn"
            ]
        },
```
