### PR TITLE
bigquery_table: Add query to view definition

### DIFF
--- a/plugins/modules/gcp_bigquery_table.py
+++ b/plugins/modules/gcp_bigquery_table.py
@@ -110,6 +110,11 @@ options:
     required: false
     type: dict
     suboptions:
+      query:
+        description:
+        - The SQL query defining this view.
+        required: false
+        type: str
       use_legacy_sql:
         description:
         - Specifies whether to use BigQuery's legacy SQL for this view .
@@ -633,6 +638,11 @@ view:
   returned: success
   type: complex
   contains:
+    query:
+      description:
+      - The SQL query defining this view.
+      returned: success
+      type: str
     useLegacySql:
       description:
       - Specifies whether to use BigQuery's legacy SQL for this view .
@@ -1019,6 +1029,7 @@ def main():
             view=dict(
                 type='dict',
                 options=dict(
+                    query=dict(type='str'),
                     use_legacy_sql=dict(type='bool'),
                     user_defined_function_resources=dict(
                         type='list', elements='dict', options=dict(inline_code=dict(type='str'), resource_uri=dict(type='str'))
@@ -1297,6 +1308,7 @@ class TableView(object):
     def to_request(self):
         return remove_nones_from_dict(
             {
+                u'query': self.request.get('query'),
                 u'useLegacySql': self.request.get('use_legacy_sql'),
                 u'userDefinedFunctionResources': TableUserdefinedfunctionresourcesArray(
                     self.request.get('user_defined_function_resources', []), self.module
@@ -1307,6 +1319,7 @@ class TableView(object):
     def from_response(self):
         return remove_nones_from_dict(
             {
+                u'query': self.request.get('query'),
                 u'useLegacySql': self.request.get(u'useLegacySql'),
                 u'userDefinedFunctionResources': TableUserdefinedfunctionresourcesArray(
                     self.request.get(u'userDefinedFunctionResources', []), self.module

--- a/plugins/modules/gcp_bigquery_table_info.py
+++ b/plugins/modules/gcp_bigquery_table_info.py
@@ -214,6 +214,11 @@ resources:
       returned: success
       type: complex
       contains:
+        query:
+          description:
+          - The SQL query defining this view.
+          returned: success
+          type: str
         useLegacySql:
           description:
           - Specifies whether to use BigQuery's legacy SQL for this view .


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds long missing API view definition query string per https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#ViewDefinition

Enables creation and maintenance of bigquery table views from SQL query string.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gcp_bigquery_table

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
