### PR TITLE
docs: remove state param in gcp_storage_object example

### DIFF
--- a/plugins/modules/gcp_storage_object.py
+++ b/plugins/modules/gcp_storage_object.py
@@ -105,7 +105,6 @@ EXAMPLES = """
     project: test_project
     auth_kind: serviceaccount
     service_account_file: "/tmp/auth.pem"
-    state: present
 """
 
 RETURN = """


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This removes a bogus parameter from the example given within the gcp_storage_object module to download an object from a GCS bucket.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gcp_storage_object

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Within the example linked below, note that it states to use the `state` parameter.

https://github.com/ansible-collections/google.cloud/blob/0cd64a4a68b7d4393c97b801e3f24e6b63882294/plugins/modules/gcp_storage_object.py#L108

Yet the module also states that the `state` parameter is not valid amongst all of the listed parameters.

https://github.com/ansible-collections/google.cloud/blob/0cd64a4a68b7d4393c97b801e3f24e6b63882294/plugins/modules/gcp_storage_object.py#L32