### PR TITLE
Fixes #494 inventory parsing continues when labels are not available when the labels entry is used

### DIFF
--- a/plugins/inventory/gcp_compute.py
+++ b/plugins/inventory/gcp_compute.py
@@ -231,7 +231,8 @@ class GcpInstance(object):
         for order in self.hostname_ordering:
             name = None
             if order.startswith("labels."):
-                name = self.json[u"labels"].get(order[7:])
+                if "labels" in self.json:
+                    name = self.json[u"labels"].get(order[7:])
             elif order == "public_ip":
                 name = self._get_publicip()
             elif order == "private_ip":


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Check if labels are present in the json file. If no labels are present, do not set name. This will cause the inventory to continue parsing and setting the next available hostname from the ordered list.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gcp_compute

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
hostnames:
- labels.name
- private_ip
```
If a vm has no labels attached it will now use the private ip

Tested behavior after change:
- Ensure label.name is set when present
- Ensure inventory continues parsing when labels are not available 
- Ensure inventory continues parsing when labels are available, but the requested labels is not present
