### PR TITLE
Add integration test instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# personal credentials are added here: do not check in.
+tests/integration/cloud-config-gcp.ini
+# running ansible integration tests adds files here.
+tests/integration/inventory
+tests/output/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to the google.cloud collection
+
+## Cloning
+
+The `ansible-test` command expects that the repository is in a directory that matches it's collection,
+under a directory `ansible_collections`. Clone ensuring that hierarchy:
+
+```shell
+mkdir -p $TARGET_DIR/ansible_collections/google
+git clone <url> $TARGET_DIR/collections/google/cloud
+```
+
+## Running tests
+
+### prequisites for all tests
+
+- Install the `ansible` package.
+
+## Running integration tests
+
+### Integration testing prequisites
+
+#### Installing personal GCP credentials
+
+The integration tests for this module require the use of real GCP credentials, and must provide
+ansible-test those values. They can be added by authoring the following in `tests/integration/cloud-config-gcp.ini`:
+
+```
+[default]
+gcp_project: @PROJECT_ID
+gcp_cred_file: @CRED_FILE
+gcp_cred_kind: @CRED_KIND
+gcp_cred_email: @EMAIL
+```
+
+### Running
+
+Run `ansible-test integration`. Currently some tests are disabled as [test are being verified and added](https://github.com/ansible-collections/google.cloud/issues/499).

--- a/tests/integration/targets/gcp_compute_region_disk/aliases
+++ b/tests/integration/targets/gcp_compute_region_disk/aliases
@@ -1,2 +1,1 @@
 cloud/gcp
-unsupported

--- a/tests/integration/targets/gcp_compute_region_disk/tasks/autogen.yml
+++ b/tests/integration/targets/gcp_compute_region_disk/tasks/autogen.yml
@@ -21,8 +21,8 @@
       raw_key: SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=
     region: us-central1
     replica_zones:
-    - https://www.googleapis.com/compute/v1/projects/google.com:graphite-playground/zones/us-central1-a
-    - https://www.googleapis.com/compute/v1/projects/google.com:graphite-playground/zones/us-central1-b
+    - https://www.googleapis.com/compute/v1/projects/{{ gcp_project }}/zones/us-central1-a
+    - https://www.googleapis.com/compute/v1/projects/{{ gcp_project }}/zones/us-central1-b
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
     service_account_file: "{{ gcp_cred_file }}"
@@ -36,8 +36,8 @@
       raw_key: SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=
     region: us-central1
     replica_zones:
-    - https://www.googleapis.com/compute/v1/projects/google.com:graphite-playground/zones/us-central1-a
-    - https://www.googleapis.com/compute/v1/projects/google.com:graphite-playground/zones/us-central1-b
+    - https://www.googleapis.com/compute/v1/projects/{{ gcp_project }}/zones/us-central1-a
+    - https://www.googleapis.com/compute/v1/projects/{{ gcp_project }}/zones/us-central1-b
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
     service_account_file: "{{ gcp_cred_file }}"
@@ -71,8 +71,8 @@
       raw_key: SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=
     region: us-central1
     replica_zones:
-    - https://www.googleapis.com/compute/v1/projects/google.com:graphite-playground/zones/us-central1-a
-    - https://www.googleapis.com/compute/v1/projects/google.com:graphite-playground/zones/us-central1-b
+    - https://www.googleapis.com/compute/v1/projects/{{ gcp_project }}/zones/us-central1-a
+    - https://www.googleapis.com/compute/v1/projects/{{ gcp_project }}/zones/us-central1-b
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
     service_account_file: "{{ gcp_cred_file }}"
@@ -91,8 +91,8 @@
       raw_key: SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=
     region: us-central1
     replica_zones:
-    - https://www.googleapis.com/compute/v1/projects/google.com:graphite-playground/zones/us-central1-a
-    - https://www.googleapis.com/compute/v1/projects/google.com:graphite-playground/zones/us-central1-b
+    - https://www.googleapis.com/compute/v1/projects/{{ gcp_project }}/zones/us-central1-a
+    - https://www.googleapis.com/compute/v1/projects/{{ gcp_project }}/zones/us-central1-b
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
     service_account_file: "{{ gcp_cred_file }}"
@@ -126,8 +126,8 @@
       raw_key: SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=
     region: us-central1
     replica_zones:
-    - https://www.googleapis.com/compute/v1/projects/google.com:graphite-playground/zones/us-central1-a
-    - https://www.googleapis.com/compute/v1/projects/google.com:graphite-playground/zones/us-central1-b
+    - https://www.googleapis.com/compute/v1/projects/{{ gcp_project }}/zones/us-central1-a
+    - https://www.googleapis.com/compute/v1/projects/{{ gcp_project }}/zones/us-central1-b
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
     service_account_file: "{{ gcp_cred_file }}"


### PR DESCRIPTION
As a step toward adding integration testing into
the CI process for this project, adding instructions
on how to run the tests.

compute_region_disk was used as a test. Fixed
the tests which was previously hard-coded to
the `graphite-playground` GCP project to work
with the project in the user-configure .ini file.