### PR TITLE
Adding integration tests on PRs

### DIFF
--- a/.github/workflows/ansible-integration-tests.yml
+++ b/.github/workflows/ansible-integration-tests.yml
@@ -1,0 +1,48 @@
+name: "Run integration tests for the cloud.google collection"
+on:
+  # NOTE: GitHub does not allow secrets to be used
+  # in PRs sent from forks. As such, this configuration is for
+  # PRs that the maintainers would like to send to test.
+  pull_request: {}
+  push:
+    branches: master
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ansible_collections/google/cloud
+    strategy:
+      matrix:
+        ansible_version:
+          # - stable-2.13
+          - stable-2.11
+    steps:
+      - name: check out code
+        uses: actions/checkout@v2
+        with:
+          path: ansible_collections/google/cloud
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.8'  # this is the minimum version required for Ansible 2.11
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Install ansible-base (${{ matrix.ansible_version }})
+        run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible_version }}.tar.gz --disable-pip-version-check
+      - name: Write integration-test configuration files
+        env:
+          CI_SERVICE_ACCOUNT_FILE_CONTENTS: ${{ secrets.CI_SERVICE_ACCOUNT_FILE_CONTENTS }}
+        run: |
+          echo "$CI_SERVICE_ACCOUNT_FILE_CONTENTS" > /tmp/service-account-key.json
+          echo "[default]
+          gcp_project: ansible-gcp-ci
+          gcp_cred_file: /tmp/service-account-key.json
+          gcp_cred_kind: serviceaccount
+          gcp_cred_email: github-ci@ansible-gcp-ci.iam.gserviceaccount.com
+          " > ./tests/integration/cloud-config-gcp.ini
+      - name: test secrets
+        env: ${{ secrets }}
+        run: echo "$CI_SERVICE_ACCOUNT_FILE_CONTENTS"
+      - name: Run integration tests
+        run: ansible-test integration -vvv --color --python 3.8 --venv-system-site-packages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,12 @@
 # Contributing to the google.cloud collection
 
+## Workflow summary
+
+1. [Clone the repository](#cloning).
+1. Make the desired code change.
+1. [Run integration tests locally and ensure they pass](running-integration-tests).
+1. Create a PR.
+
 ## Cloning
 
 The `ansible-test` command expects that the repository is in a directory that matches it's collection,

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -1,0 +1,15 @@
+# Maintainer Documentation
+
+## CI GCP Project Configuration
+
+To enable running integration tests, a test GCP project must be provided.
+
+There is a Google-maintained CI project, `ansible-gcp-ci`, that is used for this purpose. For any questions or modification to this project, please contact a maintainer who is employed by Google.
+
+## Reviewing PRs
+
+### Merging PRs
+
+Since running the full set of integration tests requires the usage of GCP
+credentials which are stored as a secret, maintainers must verify that tests pass the integration test run that runs on push to the master branch after accepting a change.
+


### PR DESCRIPTION
To help catch issues from PRs that would regress behavior, adding a GitHub action similar to unit tests to run integration tests.

Adding some basic instructions for future maintainers.
