### PR TITLE
fix compute instance + several tests

### DIFF
--- a/plugins/modules/gcp_compute_instance.py
+++ b/plugins/modules/gcp_compute_instance.py
@@ -1379,9 +1379,9 @@ def disk_type_selflink(name, params):
 def machine_type_selflink(name, params):
     if name is None:
         return
-    url = r"https://compute.googleapis.com/compute/v1/projects/.*/zones/.*/machineTypes/.*"
+    url = r"https://www.googleapis.com/compute/v1/projects/.*/zones/.*/machineTypes/.*"
     if not re.match(url, name):
-        name = "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/machineTypes/%s".format(**params) % name
+        name = "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/machineTypes/%s".format(**params) % name
     return name
 
 

--- a/tests/integration/targets/gcp_compute_autoscaler/tasks/autogen.yml
+++ b/tests/integration/targets/gcp_compute_autoscaler/tasks/autogen.yml
@@ -38,7 +38,7 @@
       - auto_delete: 'true'
         boot: 'true'
         initialize_params:
-          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts
+          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-2204-lts
       machine_type: n1-standard-1
       network_interfaces:
       - network: "{{ network }}"
@@ -216,7 +216,7 @@
       - auto_delete: 'true'
         boot: 'true'
         initialize_params:
-          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts
+          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-2204-lts
       machine_type: n1-standard-1
       network_interfaces:
       - network: "{{ network }}"

--- a/tests/integration/targets/gcp_compute_instance/aliases
+++ b/tests/integration/targets/gcp_compute_instance/aliases
@@ -1,2 +1,1 @@
 cloud/gcp
-unsupported

--- a/tests/integration/targets/gcp_compute_instance/tasks/autogen.yml
+++ b/tests/integration/targets/gcp_compute_instance/tasks/autogen.yml
@@ -263,7 +263,7 @@
   google.cloud.gcp_compute_disk:
     name: "{{ resource_prefix }}"
     size_gb: 50
-    source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts
+    source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-2204-lts
     zone: us-central1-a
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"

--- a/tests/integration/targets/gcp_compute_instance_group/aliases
+++ b/tests/integration/targets/gcp_compute_instance_group/aliases
@@ -1,2 +1,1 @@
 cloud/gcp
-unsupported

--- a/tests/integration/targets/gcp_compute_instance_group/tasks/autogen.yml
+++ b/tests/integration/targets/gcp_compute_instance_group/tasks/autogen.yml
@@ -19,6 +19,7 @@
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
     service_account_file: "{{ gcp_cred_file }}"
+    auto_create_subnetworks: true
     state: present
   register: network
 - name: delete a instance group
@@ -144,6 +145,7 @@
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
     service_account_file: "{{ gcp_cred_file }}"
+    auto_create_subnetworks: true
     state: absent
   register: network
   ignore_errors: true

--- a/tests/integration/targets/gcp_compute_instance_group_manager/aliases
+++ b/tests/integration/targets/gcp_compute_instance_group_manager/aliases
@@ -1,2 +1,1 @@
 cloud/gcp
-unsupported

--- a/tests/integration/targets/gcp_compute_instance_group_manager/tasks/autogen.yml
+++ b/tests/integration/targets/gcp_compute_instance_group_manager/tasks/autogen.yml
@@ -19,6 +19,7 @@
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
     service_account_file: "{{ gcp_cred_file }}"
+    auto_create_subnetworks: true
     state: present
   register: network
 - name: create a address
@@ -38,7 +39,7 @@
       - auto_delete: 'true'
         boot: 'true'
         initialize_params:
-          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts
+          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-2204-lts
       machine_type: n1-standard-1
       network_interfaces:
       - network: "{{ network }}"
@@ -171,7 +172,7 @@
       - auto_delete: 'true'
         boot: 'true'
         initialize_params:
-          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts
+          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-2204-lts
       machine_type: n1-standard-1
       network_interfaces:
       - network: "{{ network }}"
@@ -201,6 +202,7 @@
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
     service_account_file: "{{ gcp_cred_file }}"
+    auto_create_subnetworks: true
     state: absent
   register: network
   ignore_errors: true

--- a/tests/integration/targets/gcp_compute_instance_template/aliases
+++ b/tests/integration/targets/gcp_compute_instance_template/aliases
@@ -1,2 +1,1 @@
 cloud/gcp
-unsupported

--- a/tests/integration/targets/gcp_compute_instance_template/tasks/autogen.yml
+++ b/tests/integration/targets/gcp_compute_instance_template/tasks/autogen.yml
@@ -19,6 +19,7 @@
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
     service_account_file: "{{ gcp_cred_file }}"
+    auto_create_subnetworks: true
     state: present
   register: network
 - name: create a address
@@ -38,7 +39,7 @@
       - auto_delete: 'true'
         boot: 'true'
         initialize_params:
-          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts
+          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-2204-lts
       machine_type: n1-standard-1
       network_interfaces:
       - network: "{{ network }}"
@@ -59,7 +60,7 @@
       - auto_delete: 'true'
         boot: 'true'
         initialize_params:
-          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts
+          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-2204-lts
       machine_type: n1-standard-1
       network_interfaces:
       - network: "{{ network }}"
@@ -99,7 +100,7 @@
       - auto_delete: 'true'
         boot: 'true'
         initialize_params:
-          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts
+          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-2204-lts
       machine_type: n1-standard-1
       network_interfaces:
       - network: "{{ network }}"
@@ -125,7 +126,7 @@
       - auto_delete: 'true'
         boot: 'true'
         initialize_params:
-          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts
+          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-2204-lts
       machine_type: n1-standard-1
       network_interfaces:
       - network: "{{ network }}"
@@ -165,7 +166,7 @@
       - auto_delete: 'true'
         boot: 'true'
         initialize_params:
-          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts
+          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-2204-lts
       machine_type: n1-standard-1
       network_interfaces:
       - network: "{{ network }}"
@@ -201,6 +202,7 @@
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
     service_account_file: "{{ gcp_cred_file }}"
+    auto_create_subnetworks: true
     state: absent
   register: network
   ignore_errors: true

--- a/tests/integration/targets/gcp_compute_region_autoscaler/aliases
+++ b/tests/integration/targets/gcp_compute_region_autoscaler/aliases
@@ -1,2 +1,1 @@
 cloud/gcp
-unsupported

--- a/tests/integration/targets/gcp_compute_region_autoscaler/tasks/autogen.yml
+++ b/tests/integration/targets/gcp_compute_region_autoscaler/tasks/autogen.yml
@@ -19,6 +19,7 @@
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
     service_account_file: "{{ gcp_cred_file }}"
+    auto_create_subnetworks: true
     state: present
   register: network
 - name: create a address
@@ -38,7 +39,7 @@
       - auto_delete: 'true'
         boot: 'true'
         initialize_params:
-          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts
+          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-2204-lts
       machine_type: n1-standard-1
       network_interfaces:
       - network: "{{ network }}"
@@ -216,7 +217,7 @@
       - auto_delete: 'true'
         boot: 'true'
         initialize_params:
-          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts
+          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-2204-lts
       machine_type: n1-standard-1
       network_interfaces:
       - network: "{{ network }}"
@@ -246,6 +247,7 @@
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
     service_account_file: "{{ gcp_cred_file }}"
+    auto_create_subnetworks: true
     state: absent
   register: network
   ignore_errors: true

--- a/tests/integration/targets/gcp_compute_region_instance_group_manager/aliases
+++ b/tests/integration/targets/gcp_compute_region_instance_group_manager/aliases
@@ -1,2 +1,1 @@
 cloud/gcp
-unsupported

--- a/tests/integration/targets/gcp_compute_region_instance_group_manager/tasks/autogen.yml
+++ b/tests/integration/targets/gcp_compute_region_instance_group_manager/tasks/autogen.yml
@@ -19,6 +19,7 @@
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
     service_account_file: "{{ gcp_cred_file }}"
+    auto_create_subnetworks: true
     state: present
   register: network
 - name: create a address
@@ -38,7 +39,7 @@
       - auto_delete: 'true'
         boot: 'true'
         initialize_params:
-          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts
+          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-2204-lts
       machine_type: n1-standard-1
       network_interfaces:
       - network: "{{ network }}"
@@ -171,7 +172,7 @@
       - auto_delete: 'true'
         boot: 'true'
         initialize_params:
-          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts
+          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-2204-lts
       machine_type: n1-standard-1
       network_interfaces:
       - network: "{{ network }}"
@@ -201,6 +202,7 @@
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
     service_account_file: "{{ gcp_cred_file }}"
+    auto_create_subnetworks: true
     state: absent
   register: network
   ignore_errors: true

--- a/tests/integration/targets/gcp_compute_target_instance/aliases
+++ b/tests/integration/targets/gcp_compute_target_instance/aliases
@@ -1,2 +1,1 @@
 cloud/gcp
-unsupported

--- a/tests/integration/targets/gcp_compute_target_instance/tasks/autogen.yml
+++ b/tests/integration/targets/gcp_compute_target_instance/tasks/autogen.yml
@@ -19,6 +19,7 @@
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
     service_account_file: "{{ gcp_cred_file }}"
+    auto_create_subnetworks: true
     state: present
   register: network
 - name: create a instance
@@ -29,7 +30,7 @@
     - auto_delete: 'true'
       boot: 'true'
       initialize_params:
-        source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts
+        source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-2204-lts
     labels:
       environment: production
     network_interfaces:
@@ -150,7 +151,7 @@
     - auto_delete: 'true'
       boot: 'true'
       initialize_params:
-        source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts
+        source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-2204-lts
     labels:
       environment: production
     network_interfaces:
@@ -168,6 +169,7 @@
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
     service_account_file: "{{ gcp_cred_file }}"
+    auto_create_subnetworks: true
     state: absent
   register: network
   ignore_errors: true

--- a/tests/integration/targets/gcp_compute_target_pool/aliases
+++ b/tests/integration/targets/gcp_compute_target_pool/aliases
@@ -1,2 +1,1 @@
 cloud/gcp
-unsupported


### PR DESCRIPTION
compute selflinks return back `wwww.googleapis.com` as the domain, which was causing a perma-diff. Fixing google.cloud's normalization fixes that.

Fixing the following tests as well, since creating an instance now works:

- gcp_compute_instance
- gcp_compute_instance_group
- gcp_compute_instance_group_manager
- gcp_compute_instance_template
- gcp_compute_region_autoscaler
- gcp_compute_region_instance_group_manager
- gcp_compute_target_instance
- gcp_compute_target_pool