### PR TITLE
fix: added missing zone parameter in gcp_compute_instance_template

### DIFF
--- a/plugins/modules/gcp_compute_instance_template.py
+++ b/plugins/modules/gcp_compute_instance_template.py
@@ -165,6 +165,7 @@ options:
                 - Reference to a disk type.
                 - Specifies the disk type to use to create the instance.
                 - If not specified, the default is pd-standard.
+                - To use this parameter specify zone parameter as well.
                 required: false
                 type: str
               source_image:
@@ -472,6 +473,11 @@ options:
             elements: str
             required: false
             type: list
+  zone:
+    description:
+    - A reference to the zone where the disk type resides
+    required: false
+    type: str
   project:
     description:
     - The Google Cloud Platform project to use.

--- a/tests/integration/targets/gcp_compute_instance_template/tasks/autogen.yml
+++ b/tests/integration/targets/gcp_compute_instance_template/tasks/autogen.yml
@@ -157,6 +157,92 @@
   assert:
     that:
       - results['resources'] | length == 0
+#----------------------------------------------------------
+- name: create a instance template with ssd disk type
+  google.cloud.gcp_compute_instance_template:
+    name: "{{ resource_name }}"
+    properties:
+      disks:
+      - auto_delete: 'true'
+        boot: 'true'
+        initialize_params:
+          disk_size_gb: 10
+          disk_type: "pd-ssd"
+          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-2204-lts
+      machine_type: n1-standard-1
+      network_interfaces:
+      - network: "{{ network }}"
+        access_configs:
+        - name: test-config
+          type: ONE_TO_ONE_NAT
+          nat_ip: "{{ address }}"
+    zone: us-central1-a
+    project: "{{ gcp_project }}"
+    auth_kind: "{{ gcp_cred_kind }}"
+    service_account_file: "{{ gcp_cred_file }}"
+    state: present
+  register: result
+- name: assert changed is true
+  assert:
+    that:
+      - result.changed == true
+- name: verify that instance_template was created
+  google.cloud.gcp_compute_instance_template_info:
+      filters:
+         - name = {{ resource_name }}
+      project: "{{ gcp_project }}"
+      auth_kind: "{{ gcp_cred_kind }}"
+      service_account_file: "{{ gcp_cred_file }}"
+      scopes:
+        - https://www.googleapis.com/auth/compute
+  register: results
+- name: verify that command succeeded
+  assert:
+    that:
+      - results['resources'] | length == 1
+#----------------------------------------------------------
+- name: delete a instance template
+  google.cloud.gcp_compute_instance_template:
+    name: "{{ resource_name }}"
+    properties:
+      disks:
+      - auto_delete: 'true'
+        boot: 'true'
+        initialize_params:
+          disk_size_gb: 10
+          disk_type: "pd-ssd"
+          source_image: projects/ubuntu-os-cloud/global/images/family/ubuntu-minimal-2204-lts
+      machine_type: n1-standard-1
+      network_interfaces:
+      - network: "{{ network }}"
+        access_configs:
+        - name: test-config
+          type: ONE_TO_ONE_NAT
+          nat_ip: "{{ address }}"
+    zone: us-central1-a
+    project: "{{ gcp_project }}"
+    auth_kind: "{{ gcp_cred_kind }}"
+    service_account_file: "{{ gcp_cred_file }}"
+    state: absent
+  register: result
+- name: assert changed is true
+  assert:
+    that:
+      - result.changed == true
+- name: verify that instance_template was deleted
+  google.cloud.gcp_compute_instance_template_info:
+      filters:
+         - name = {{ resource_name }}
+      project: "{{ gcp_project }}"
+      auth_kind: "{{ gcp_cred_kind }}"
+      service_account_file: "{{ gcp_cred_file }}"
+      scopes:
+        - https://www.googleapis.com/auth/compute
+  register: results
+- name: verify that command succeeded
+  assert:
+    that:
+      - results['resources'] | length == 0
 # ----------------------------------------------------------------------------
 - name: delete a instance template that does not exist
   google.cloud.gcp_compute_instance_template:


### PR DESCRIPTION
##### SUMMARY
`gcp_compute_instance_template` is missing `zone` parameter

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module `gcp_compute_instance_template`

##### ADDITIONAL INFORMATION
I was trying to create an instance template by providing `pd_ssd` disk type
```
---
  - name: gcp vm instance
    hosts: localhost
    gather_facts: true
    vars_files:
      - vars.yaml
    tasks:
      - name: create an instance template
        google.cloud.gcp_compute_instance_template:
          name: "{{ instance_template_name }}"
          properties:
            disks:
            - auto_delete: 'true'
              boot: 'true'
              initialize_params:
                disk_size_gb: "200"
                disk_type: "pd_ssd"
                source_image: "projects/centos-cloud/global/images/centos-7-v20221102"
            machine_type: "{{ machine_type }}"
            metadata:
              startup-script: |
                sudo yum update
                sudo yum install -y mysql-server
            network_interfaces:
              - network:
                  selfLink: "projects/{{ project_id }}/global/networks/default"
          project: "{{ project_id }}"
          auth_kind: serviceaccount
          service_account_file: "{{ service_account_file }}"
          state: present
```
It turned out that [function](https://github.com/ansible-collections/google.cloud/blob/master/plugins/modules/gcp_compute_instance_template.py#L1208) inside module requires `zone` parameter
```
def disk_type_selflink(name, params):
    if name is None:
        return
    url = r"https://compute.googleapis.com/compute/v1/projects/.*/zones/.*/diskTypes/.*"
    if not re.match(url, name):
        name = "https://compute.googleapis.com/compute/v1/projects/{project}/zones/{zone}/diskTypes/%s".format(**params) % name
    return name
```

When I run `ansible-playbook playbook.yaml` I get this error:
```
  File "/var/folders/07/b8b1dky11434yyql0k2451_m0000gn/T/ansible_google.cloud.gcp_compute_instance_template_payload_1bcy5hhm/ansible_google.cloud.gcp_compute_instance_template_payload.zip/ansible_collections/google/cloud/plugins/modules/gcp_compute_instance_template.py", line 1208, in disk_type_selflink
KeyError: 'zone'
```