### PR TITLE
fix: gcp_container_cluster for GKE 1.19+

### DIFF
--- a/tests/integration/targets/gcp_container_cluster/aliases
+++ b/tests/integration/targets/gcp_container_cluster/aliases
@@ -1,2 +1,1 @@
 cloud/gcp
-unsupported

--- a/tests/integration/targets/gcp_container_cluster/tasks/autogen.yml
+++ b/tests/integration/targets/gcp_container_cluster/tasks/autogen.yml
@@ -17,15 +17,12 @@
   google.cloud.gcp_container_cluster:
     name: my-cluster
     initial_node_count: 2
-    master_auth:
-      username: cluster_admin
-      password: my-secret-password
     node_config:
       machine_type: n1-standard-4
       disk_size_gb: 500
     location: us-central1-a
     project: "{{ gcp_project }}"
-    auth_kind: "{{ gcp_cred_kind }}"
+    auth_kind: "serviceaccount"
     service_account_file: "{{ gcp_cred_file }}"
     state: absent
 #----------------------------------------------------------
@@ -33,15 +30,12 @@
   google.cloud.gcp_container_cluster:
     name: my-cluster
     initial_node_count: 2
-    master_auth:
-      username: cluster_admin
-      password: my-secret-password
     node_config:
       machine_type: n1-standard-4
       disk_size_gb: 500
     location: us-central1-a
     project: "{{ gcp_project }}"
-    auth_kind: "{{ gcp_cred_kind }}"
+    auth_kind: "serviceaccount"
     service_account_file: "{{ gcp_cred_file }}"
     state: present
   register: result
@@ -53,7 +47,7 @@
   google.cloud.gcp_container_cluster_info:
       location: us-central1-a
       project: "{{ gcp_project }}"
-      auth_kind: "{{ gcp_cred_kind }}"
+      auth_kind: "serviceaccount"
       service_account_file: "{{ gcp_cred_file }}"
       scopes:
         - https://www.googleapis.com/auth/cloud-platform
@@ -67,15 +61,12 @@
   google.cloud.gcp_container_cluster:
     name: my-cluster
     initial_node_count: 2
-    master_auth:
-      username: cluster_admin
-      password: my-secret-password
     node_config:
       machine_type: n1-standard-4
       disk_size_gb: 500
     location: us-central1-a
     project: "{{ gcp_project }}"
-    auth_kind: "{{ gcp_cred_kind }}"
+    auth_kind: "serviceaccount"
     service_account_file: "{{ gcp_cred_file }}"
     state: present
   register: result
@@ -88,15 +79,12 @@
   google.cloud.gcp_container_cluster:
     name: my-cluster
     initial_node_count: 2
-    master_auth:
-      username: cluster_admin
-      password: my-secret-password
     node_config:
       machine_type: n1-standard-4
       disk_size_gb: 500
     location: us-central1-a
     project: "{{ gcp_project }}"
-    auth_kind: "{{ gcp_cred_kind }}"
+    auth_kind: "serviceaccount"
     service_account_file: "{{ gcp_cred_file }}"
     state: absent
   register: result
@@ -122,15 +110,12 @@
   google.cloud.gcp_container_cluster:
     name: my-cluster
     initial_node_count: 2
-    master_auth:
-      username: cluster_admin
-      password: my-secret-password
     node_config:
       machine_type: n1-standard-4
       disk_size_gb: 500
     location: us-central1-a
     project: "{{ gcp_project }}"
-    auth_kind: "{{ gcp_cred_kind }}"
+    auth_kind: "serviceaccount"
     service_account_file: "{{ gcp_cred_file }}"
     state: absent
   register: result

--- a/tests/integration/targets/gcp_container_node_pool/aliases
+++ b/tests/integration/targets/gcp_container_node_pool/aliases
@@ -1,2 +1,1 @@
 cloud/gcp
-unsupported


### PR DESCRIPTION
Incorporating a fix for GKE 1.19+ (See #444).

Inlined:

Google has removed basic-auth method from within GKE starting version 1.19 This lead the output response of the backend API not to provide basic-auth data (username and password) anymore.

The current implementation of gcp_container_cluster when generating the kubectl config file, always set basic-auth data w/o checking if there actually are available or explicitly provided even when the value are not set/provided from gcp_container_cluster.

In addition, re-enabling some tests that #444 fixed.

Co-authored-by: Xavier Lamien <laxathom@lxtnow.net>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
