### PR TITLE
fix role tests and document unsupported CI tests

### DIFF
--- a/.github/workflows/ansible-integration-tests.yml
+++ b/.github/workflows/ansible-integration-tests.yml
@@ -1,8 +1,5 @@
 name: "Run integration tests for the cloud.google collection"
 on:
-  # NOTE: GitHub does not allow secrets to be used
-  # in PRs sent from forks. As such, this configuration is for
-  # PRs that the maintainers would like to send to test.
   pull_request: {}
   push:
     branches: master
@@ -11,6 +8,10 @@ env:
   GCP_PROJECT: "ansible-gcp-ci"
 jobs:
   integration:
+    # NOTE: GitHub does not allow secrets to be used
+    # in PRs sent from forks. As such, this configuration is for
+    # PRs that the maintainers would like to send to test.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/gcloud.yml
+++ b/.github/workflows/gcloud.yml
@@ -22,17 +22,6 @@ jobs:
         molecule_playbook:
           - archive_playbook.yml
           - package_playbook.yml
-        molecule_distro:
-          - distro: centos:7
-            command: /usr/sbin/init
-          - distro: centos:8
-            command: /usr/sbin/init
-          - distro: ubuntu:18.04
-            command: /lib/systemd/systemd
-          - distro: ubuntu:20.04
-            command: /lib/systemd/systemd
-          - distro: debian:9
-            command: /lib/systemd/systemd
         collection_role:
           - gcloud
     steps:
@@ -58,14 +47,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y docker-ce docker-ce-cli containerd.io
           python -m pip install --upgrade pip
-          pip install molecule yamllint ansible ansible-lint docker \
-            molecule[docker]
+          pip install molecule[docker] yamllint ansible ansible-lint docker
 
       - name: Run role test
         run: >-
           molecule --version &&
           ansible --version &&
-          MOLECULE_COMMAND=${{ matrix.molecule_distro.command }}
-          MOLECULE_DISTRO=${{ matrix.molecule_distro.distro }}
           MOLECULE_PLAYBOOK=${{ matrix.molecule_playbook }}
+          MOLECULE_NO_LOG="false"
           molecule --debug test -s ${{ matrix.collection_role }}

--- a/.github/workflows/gcsfuse.yml
+++ b/.github/workflows/gcsfuse.yml
@@ -17,13 +17,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        molecule_distro:
-          - distro: ubuntu:16.04
-            command: /sbin/init
-          - distro: ubuntu:18.04
-            command: /lib/systemd/systemd
-          - distro: debian:9
-            command: /lib/systemd/systemd
         collection_role:
           - gcsfuse
     steps:
@@ -39,14 +32,21 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt install docker
+          sudo apt-get install -y apt-transport-https ca-certificates curl gnupg \
+            lsb-release
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg \
+            --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+          echo \
+            "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+            $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y docker-ce docker-ce-cli containerd.io
           python -m pip install --upgrade pip
-          pip install molecule yamllint ansible-lint docker
+          pip install molecule[docker] yamllint ansible ansible-lint docker
 
       - name: Run role test
         run: >-
           molecule --version &&
           ansible --version &&
-          MOLECULE_COMMAND=${{ matrix.molecule_distro.command }}
-          MOLECULE_DISTRO=${{ matrix.molecule_distro.distro }}
+          MOLECULE_NO_LOG="false"
           molecule --debug test -s ${{ matrix.collection_role }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ git clone <url> $TARGET_DIR/collections/google/cloud
 ### prequisites for all tests
 
 - Install the `ansible` package.
+- Some container runtime is necessary (e.g. `podman` or `docker`). The instructions use podman.
 
 ## Running integration tests
 
@@ -57,3 +58,32 @@ bash ./scripts/bootstrap-project.sh $PROJECT_ID $SERVICE_ACCOUNT_NAME
 ### Running
 
 Run `ansible-test integration`. Currently some tests are disabled as [test are being verified and added](https://github.com/ansible-collections/google.cloud/issues/499).
+
+## Role tests
+
+### Prequisites for role tests
+
+If you would like to use podman, you must
+install the `molecule[podman]` package in PyPI:
+
+```
+pip install --upgrade molecule[podman]
+```
+
+### Running role tests
+
+Ansible roles are tested via molecule.
+
+```sh
+module debug --test -s ${ROLE}
+```
+
+Role is the name of the role (e.g. gcloud, gcsfuse).
+
+Add `-d podman` if you would like to use the podman driver.
+
+If the linting fails, that is generally due to `ansible-lint`, which can be run directly:
+
+```
+ansible-lint
+```

--- a/molecule/gcloud/archive_playbook.yml
+++ b/molecule/gcloud/archive_playbook.yml
@@ -3,7 +3,7 @@
   hosts: all
   pre_tasks:
     - name: Install gpg for apt_key
-      apt:
+      ansible.builtin.apt:
         name: gnupg
         update_cache: true
       when: ansible_os_family|lower == "debian"

--- a/molecule/gcloud/converge.yml
+++ b/molecule/gcloud/converge.yml
@@ -3,20 +3,20 @@
   hosts: all
   pre_tasks:
     - name: Update package cache
-      package: update_cache=yes
+      ansible.builtin.package: update_cache=yes
       changed_when: false
       register: task_result
       until: task_result is success
       retries: 10
       delay: 2
     - name: create containerd folder
-      file:
+      ansible.builtin.file:
         path: /etc/systemd/system/containerd.service.d
         state: directory
         mode: 0755
       when: ansible_service_mgr == "systemd"
     - name: override file for containerd
-      copy:
+      ansible.builtin.copy:
         src: files/override.conf
         dest: /etc/systemd/system/containerd.service.d/override.conf
         mode: 0644

--- a/molecule/gcloud/molecule.yml
+++ b/molecule/gcloud/molecule.yml
@@ -9,9 +9,15 @@ lint: |
   ansible-lint
 platforms:
   - name: instance
-    image: ${MOLECULE_DISTRO:-ubuntu:xenial}
+    image: ubuntu:18.04
     privileged: true
-    command: ${MOLECULE_COMMAND:-"sleep infinity"}
+    ansible.builtin.command: "/lib/systemd/systemd"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  - name: instance
+    image: debian:9
+    privileged: true
+    ansible.builtin.command: "/lib/systemd/systemd"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
 provisioner:

--- a/molecule/gcloud/package_playbook.yml
+++ b/molecule/gcloud/package_playbook.yml
@@ -3,7 +3,7 @@
   hosts: all
   pre_tasks:
     - name: Install gpg for apt_key
-      apt:
+      ansible.builtin.apt:
         name: gnupg
         update_cache: true
       when: ansible_os_family|lower == "debian"

--- a/molecule/gcloud/verify.yml
+++ b/molecule/gcloud/verify.yml
@@ -5,5 +5,5 @@
   hosts: all
   tasks:
   - name: Example assertion
-    assert:
+    ansible.builtin.assert:
       that: true

--- a/molecule/gcsfuse/converge.yml
+++ b/molecule/gcsfuse/converge.yml
@@ -2,25 +2,12 @@
 - name: Converge
   hosts: all
   pre_tasks:
-    - name: Using apt update the packages
-      apt:
-        update_cache: yes
-      when: ansible_os_family == "Debian"
-    - name: Using apt update the packages
-      yum:
-        update_cache: yes
-      when: ansible_os_family == "RedHat"
-    - name: create containerd folder
-      file:
-        path: /etc/systemd/system/containerd.service.d
-        state: directory
-        mode: 0755
-      when: ansible_service_mgr == "systemd"
-    - name: override file for containerd
-      copy:
-        src: files/override.conf
-        dest: /etc/systemd/system/containerd.service.d/override.conf
-        mode: 0644
-      when: ansible_service_mgr == "systemd"
+    - name: Update package cache
+      ansible.builtin.package: update_cache=yes
+      changed_when: false
+      register: task_result
+      until: task_result is success
+      retries: 10
+      delay: 2
   roles:
     - role: google.cloud.gcsfuse

--- a/molecule/gcsfuse/molecule.yml
+++ b/molecule/gcsfuse/molecule.yml
@@ -9,9 +9,15 @@ lint: |
   ansible-lint
 platforms:
   - name: instance
-    image: ${MOLECULE_DISTRO:-ubuntu:xenial}
+    image: ubuntu:18.04
     privileged: true
-    command: ${MOLECULE_COMMAND:-"sleep infinity"}
+    ansible.builtin.command: "/lib/systemd/systemd"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  - name: instance
+    image: debian:9
+    privileged: true
+    ansible.builtin.command: "/lib/systemd/systemd"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
 provisioner:

--- a/molecule/gcsfuse/verify.yml
+++ b/molecule/gcsfuse/verify.yml
@@ -5,5 +5,5 @@
   hosts: all
   tasks:
   - name: Example assertion
-    assert:
+    ansible.builtin.assert:
       that: true

--- a/roles/gcloud/tasks/archive/archive_install.yml
+++ b/roles/gcloud/tasks/archive/archive_install.yml
@@ -1,16 +1,16 @@
 ---
 - name: gcloud | Archive | Ensure temp path exists
-  file: path={{ gcloud_archive_path }} state=directory mode=0755
+  ansible.builtin.file: path={{ gcloud_archive_path }} state=directory mode=0755
 
 - name: gcloud | Archive | Extract Cloud SDK archive
-  unarchive:
+  ansible.builtin.unarchive:
     src: "{{ gcloud_archive_url }}"
     dest: "{{ gcloud_archive_path }}"
     remote_src: yes
     creates: "{{ gcloud_library_path }}"
 
 - name: gcloud | Archive | Link binaries to /usr/bin (like package install)
-  file:
+  ansible.builtin.file:
     src: "{{ gcloud_library_path }}/bin/{{ item }}"
     dest: "/usr/bin/{{ item }}"
     state: link
@@ -23,11 +23,11 @@
   when: not gcloud_install_script
 
 - name: gcloud | Archive | Add command completion
-  include_tasks: command_completion.yml
+  ansible.builtin.include_tasks: command_completion.yml
   when: gcloud_command_completion
 
 - name: gcloud | Archive | Install into Path
-  command: >-
+  ansible.builtin.command: >-
     {{ gcloud_archive_path }}/install.sh --quiet
     --usage-reporting {{ gcloud_usage_reporting | lower }}
     {% if gcloud_profile_path %}

--- a/roles/gcloud/tasks/archive/command_completion.yml
+++ b/roles/gcloud/tasks/archive/command_completion.yml
@@ -1,7 +1,7 @@
 ---
 # task file to configure bash completion for gcloud
 - name: gcloud | Archive | Debian | Ensure bash completion is installed
-  apt: name=bash-completion
+  ansible.builtin.apt: name=bash-completion
   register: task_result
   until: task_result is success
   retries: 10
@@ -9,7 +9,7 @@
   when: ansible_os_family == "Debian"
 
 - name: gcloud | Archive | RedHat | Ensure bash completion is installed
-  yum:
+  ansible.builtin.yum:
     name:
       - bash-completion
   register: task_result
@@ -19,7 +19,7 @@
   when: ansible_os_family == "RedHat"
 
 - name: gcloud | Archive | Ensure bash_completion.d directory exists
-  file:
+  ansible.builtin.file:
     path: /etc/bash_completion.d
     owner: root
     group: root
@@ -27,7 +27,7 @@
     mode: 0755
 
 - name: gcloud | Archive | Link binaries to /usr/bin (like package install)
-  file:
+  ansible.builtin.file:
     src: "{{ gcloud_library_path }}/completion.bash.inc"
     dest: /etc/bash_completion.d/gcloud
     state: link

--- a/roles/gcloud/tasks/archive/main.yml
+++ b/roles/gcloud/tasks/archive/main.yml
@@ -1,27 +1,27 @@
 ---
 # tasks to install gcloud via archive
 - name: gcloud | Archive | Look for existing Google Cloud SDK installation
-  stat:
+  ansible.builtin.stat:
     path: "{{ gcloud_archive_path }}/google-cloud-sdk/VERSION"
   register: gcloud_status
 
 - name: gcloud | Archive | Get gcloud_status
-  debug: var=gcloud_status
+  ansible.builtin.debug: var=gcloud_status
 
 - name: gcloud | Archive | Set installed version if installation exists
   block:
-    - name: gcloud | Archive | Importing contents of {{ gcloud_archive_path }}/google-cloud-sdk/VERSION
-      slurp:
+    - name: gcloud | Archive | Importing contents of ./google-cloud-sdk/VERSION in {{ gcloud_archive_path }}
+      ansible.builtin.slurp:
         src: "{{ gcloud_archive_path }}/google-cloud-sdk/VERSION"
       register: gcloud_installed_version_data
     - name: gcloud | Archive | Setting the gcloud_installed_version variable/fact
-      set_fact:
+      ansible.builtin.set_fact:
         gcloud_installed_version: "{{ (gcloud_installed_version_data.content|b64decode|trim) }}"
     - name: gcloud | Archive | get the gcloud_installed_version
-      debug:
+      ansible.builtin.debug:
         msg: "google-cloud-sdk: {{ gcloud_installed_version }} is installed"
     - name: gcloud | Archive | Version already installed
-      debug:
+      ansible.builtin.debug:
         msg: >-
           Skipping installation of google-cloud-sdk version {{ gcloud_version }} when
           {{ gcloud_installed_version }} is already installed.
@@ -29,12 +29,12 @@
   when: gcloud_status.stat.exists
 
 - name: gcloud | Archive | Start installation
-  include_tasks: archive_install.yml
+  ansible.builtin.include_tasks: archive_install.yml
   when: gcloud_installed_version is undefined or
         gcloud_version is version(gcloud_installed_version, '>')
 
 - name: gcloud | Debian | Install the google-cloud-sdk additional components # noqa 301
-  command: gcloud components install {{ item }}
+  ansible.builtin.command: gcloud components install {{ item }}
   register: gcloud_install_comp_status
   changed_when: "'All components are up to date.' not in gcloud_install_comp_status.stderr_lines"
   loop: "{{ gcloud_additional_components }}"

--- a/roles/gcloud/tasks/main.yml
+++ b/roles/gcloud/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: gcloud | Load Distro and OS specific variables
-  include_vars: "{{ lookup('first_found', params) }}"
+  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
   vars:
     params:
       files:
@@ -12,4 +12,4 @@
         - 'vars'
 
 - name: gcloud | Install the google-cloud-sdk from {{ gcloud_install_type }}
-  include_tasks: "{{ gcloud_install_type }}/main.yml"
+  ansible.builtin.include_tasks: "{{ gcloud_install_type }}/main.yml"

--- a/roles/gcloud/tasks/package/debian.yml
+++ b/roles/gcloud/tasks/package/debian.yml
@@ -1,25 +1,25 @@
 ---
 # tasks that install gcloud on debian
 - name: gcloud | Debian | Add an Apt signing key, uses whichever key is at the URL
-  apt_key:
+  ansible.builtin.apt_key:
     url: "{{ gcloud_apt_key }}"
     state: present
 
 - name: gcloud | Debian | Add the gcloud repository
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: "deb {{ gcloud_apt_url }} {{ gcloud_apt_repo }} main"
     state: present
     filename: google-cloud-sdk
 
 - name: gcloud | Debian | Install the google-cloud-sdk package
-  apt: name=google-cloud-sdk update_cache=yes
+  ansible.builtin.apt: name=google-cloud-sdk update_cache=yes
   register: task_result
   until: task_result is success
   retries: 10
   delay: 2
 
 - name: gcloud | Debian | Install the google-cloud-sdk additional components
-  apt: name=google-cloud-sdk-{{ item }} update_cache=yes
+  ansible.builtin.apt: name=google-cloud-sdk-{{ item }} update_cache=yes
   register: task_result
   until: task_result is success
   retries: 10

--- a/roles/gcloud/tasks/package/main.yml
+++ b/roles/gcloud/tasks/package/main.yml
@@ -2,4 +2,4 @@
 # tasks file for gcloud
 
 - name: gcloud | Start package installation for specific distro
-  include_tasks: "{{ ansible_os_family|lower }}.yml"
+  ansible.builtin.include_tasks: "{{ ansible_os_family|lower }}.yml"

--- a/roles/gcloud/tasks/package/redhat.yml
+++ b/roles/gcloud/tasks/package/redhat.yml
@@ -1,9 +1,9 @@
 ---
 - name: gcloud | RHEL | Add an Apt signing key, uses whichever key is at the URL
-  yum_repository:
+  ansible.builtin.yum_repository:
     name: google-cloud-sdk
     description: Google Cloud SDK
-    file: google-cloud-sdk
+    ansible.builtin.file: google-cloud-sdk
     baseurl: https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
     enabled: yes
     gpgcheck: yes
@@ -13,14 +13,14 @@
       - https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 
 - name: gcloud | RHEL | Install the google-cloud-sdk package
-  yum: name=google-cloud-sdk update_cache=yes
+  ansible.builtin.yum: name=google-cloud-sdk update_cache=yes
   register: task_result
   until: task_result is success
   retries: 10
   delay: 2
 
 - name: gcloud | Debian | Install the google-cloud-sdk additional components
-  yum: name=google-cloud-sdk-{{ item }} update_cache=yes
+  ansible.builtin.yum: name=google-cloud-sdk-{{ item }} update_cache=yes
   register: task_result
   until: task_result is success
   retries: 10

--- a/roles/gcsfuse/tasks/debian.yml
+++ b/roles/gcsfuse/tasks/debian.yml
@@ -1,24 +1,24 @@
 ---
 - name: gcsfuse | Ensure gpg is installed
-  apt: name=gnupg
+  ansible.builtin.apt: name=gnupg
   register: task_result
   until: task_result is success
   retries: 10
   delay: 2
 
 - name: gcsfuse | Add an apt signing key
-  apt_key:
+  ansible.builtin.apt_key:
     url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
     state: present
 
 - name: gcsfuse | Add the apt repository
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: deb http://packages.cloud.google.com/apt gcsfuse-{{ ansible_distribution_release }} main
     state: present
     filename: gcsfuse
 
 - name: gcsfuse | Install gcsfuse
-  apt: name=gcsfuse update_cache=yes
+  ansible.builtin.apt: name=gcsfuse update_cache=yes
   register: task_result
   until: task_result is success
   retries: 10

--- a/roles/gcsfuse/tasks/main.yml
+++ b/roles/gcsfuse/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
 # tasks file for google.cloud.gcsfuse
-
-- include_tasks: "{{ ansible_os_family|lower }}.yml"
+- name: main
+  ansible.builtin.include_tasks: "{{ ansible_os_family|lower }}.yml"

--- a/tests/integration/targets/gcp_compute_node_group/aliases
+++ b/tests/integration/targets/gcp_compute_node_group/aliases
@@ -1,2 +1,5 @@
 cloud/gcp
+# this test cannot run in CI, as the minimum
+# node group size is beyond the compute quota
+# limit of a default project.
 unsupported

--- a/tests/integration/targets/gcp_compute_region_target_https_proxy/aliases
+++ b/tests/integration/targets/gcp_compute_region_target_https_proxy/aliases
@@ -1,2 +1,4 @@
 cloud/gcp
+# unsupported as testing this resource requires
+# a missing resource (compute_regional_ssl_cert)
 unsupported

--- a/tests/integration/targets/gcp_resourcemanager_project/aliases
+++ b/tests/integration/targets/gcp_resourcemanager_project/aliases
@@ -1,2 +1,4 @@
 cloud/gcp
+# unsupported as CI test project does not support
+# creating folders / projects to test.
 unsupported

--- a/tests/integration/targets/gcp_sql_ssl_cert/aliases
+++ b/tests/integration/targets/gcp_sql_ssl_cert/aliases
@@ -1,2 +1,4 @@
 cloud/gcp
+# unsupported as gcp_sql_ssl_cert_info resource
+# does not exist.
 unsupported


### PR DESCRIPTION
Some test cases are unsupported due to environmental or
blocking code restrictions (e.g. unimplemented dependent resources).

As these will likely not be fixed before the first release certified
for Ansible 2.11 and beyond, documenting them instead.

Ansible role tests were failing due to ansible-lint reporting
multiple errors.

Fixing those errors resolves the failing tests.