### PR TITLE
tests: fix integration tests not running on push

### DIFF
--- a/.github/workflows/ansible-integration-tests.yml
+++ b/.github/workflows/ansible-integration-tests.yml
@@ -11,7 +11,7 @@ jobs:
     # NOTE: GitHub does not allow secrets to be used
     # in PRs sent from forks. As such, this configuration is for
     # PRs that the maintainers would like to send to test.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.push != null || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
The integration test filter syntax was restrictive and disabled running them on push.

