### PR TITLE
tests: fix integration tests 2 

### DIFF
--- a/.github/workflows/ansible-integration-tests.yml
+++ b/.github/workflows/ansible-integration-tests.yml
@@ -11,7 +11,7 @@ jobs:
     # NOTE: GitHub does not allow secrets to be used
     # in PRs sent from forks. As such, this configuration is for
     # PRs that the maintainers would like to send to test.
-    if: github.event.push != null || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
the previous fix had invalid syntax (hard to test against the
master branch until after push).

This syntax is documented as correct:
https://github.com/actions/runner/issues/950