### PR TITLE
fixing ansible-lint errors, fix gcsfuse

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 env:
   PYTHON_VERSION: "3.9" # minimum version for Ansible 2.14
 jobs:
-  sanity:
+  sanity-and-lint:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -22,14 +22,14 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install ansible-base (${{ matrix.ansible_version }})
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 3
-          max_attempts: 3
-          command: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible_version }}.tar.gz --disable-pip-version-check
-      - name: Run sanity tests
+        run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible_version }}.tar.gz --disable-pip-version-check
+      - name: Run ansible-test sanity
         # validate-modules cannot be turned on until #498 is resolved.
         run: ansible-test sanity -v --color --python "$PYTHON_VERSION" --skip validate-modules
+      - name: Install ansible-lint
+        run: pip install ansible-lint
+      - name: Run ansible-lint
+        run: ansible-lint
   unit:
     runs-on: ubuntu-latest
     defaults:

--- a/molecule/gcloud/archive_playbook.yml
+++ b/molecule/gcloud/archive_playbook.yml
@@ -6,7 +6,7 @@
       ansible.builtin.apt:
         name: gnupg
         update_cache: true
-      when: ansible_os_family|lower == "debian"
+      when: ansible_os_family | lower == "debian"
   roles:
     - role: google.cloud.gcloud
       gcloud_install_type: archive

--- a/molecule/gcloud/converge.yml
+++ b/molecule/gcloud/converge.yml
@@ -3,19 +3,20 @@
   hosts: all
   pre_tasks:
     - name: Update package cache
-      ansible.builtin.package: update_cache=yes
+      ansible.builtin.package:
+        update_cache: "yes"
       changed_when: false
       register: task_result
       until: task_result is success
       retries: 10
       delay: 2
-    - name: create containerd folder
+    - name: Create containerd folder
       ansible.builtin.file:
         path: /etc/systemd/system/containerd.service.d
         state: directory
         mode: 0755
       when: ansible_service_mgr == "systemd"
-    - name: override file for containerd
+    - name: Override file for containerd
       ansible.builtin.copy:
         src: files/override.conf
         dest: /etc/systemd/system/containerd.service.d/override.conf

--- a/molecule/gcloud/package_playbook.yml
+++ b/molecule/gcloud/package_playbook.yml
@@ -6,7 +6,7 @@
       ansible.builtin.apt:
         name: gnupg
         update_cache: true
-      when: ansible_os_family|lower == "debian"
+      when: ansible_os_family | lower == "debian"
   roles:
     - role: google.cloud.gcloud
       gcloud_additional_components:

--- a/molecule/gcsfuse/converge.yml
+++ b/molecule/gcsfuse/converge.yml
@@ -3,7 +3,8 @@
   hosts: all
   pre_tasks:
     - name: Update package cache
-      ansible.builtin.package: update_cache=yes
+      ansible.builtin.package:
+        update_cache: "yes"
       changed_when: false
       register: task_result
       until: task_result is success

--- a/roles/gcloud/tasks/archive/archive_install.yml
+++ b/roles/gcloud/tasks/archive/archive_install.yml
@@ -1,6 +1,9 @@
 ---
 - name: gcloud | Archive | Ensure temp path exists
-  ansible.builtin.file: path={{ gcloud_archive_path }} state=directory mode=0755
+  ansible.builtin.file:
+    path: "{{ gcloud_archive_path }}"
+    state: "directory"
+    mode: "0755"
 
 - name: gcloud | Archive | Extract Cloud SDK archive
   ansible.builtin.unarchive:
@@ -37,7 +40,7 @@
     --path-update {{ gcloud_update_path | lower }}
     {% if gcloud_override_components | length > 0 %}--override-components
       {% for component in gcloud_override_components %}{{ component }}
-        {% if loop.index < gcloud_override_components | length  %}
+        {% if loop.index < gcloud_override_components | length %}
         {% endif %}
       {% endfor %}
     {% endif %}

--- a/roles/gcloud/tasks/archive/command_completion.yml
+++ b/roles/gcloud/tasks/archive/command_completion.yml
@@ -1,7 +1,8 @@
 ---
 # task file to configure bash completion for gcloud
 - name: gcloud | Archive | Debian | Ensure bash completion is installed
-  ansible.builtin.apt: name=bash-completion
+  ansible.builtin.apt:
+    name: "bash-completion"
   register: task_result
   until: task_result is success
   retries: 10

--- a/roles/gcloud/tasks/archive/main.yml
+++ b/roles/gcloud/tasks/archive/main.yml
@@ -6,9 +6,11 @@
   register: gcloud_status
 
 - name: gcloud | Archive | Get gcloud_status
-  ansible.builtin.debug: var=gcloud_status
+  ansible.builtin.debug:
+    var: "gcloud_status"
 
 - name: gcloud | Archive | Set installed version if installation exists
+  when: gcloud_status.stat.exists
   block:
     - name: gcloud | Archive | Importing contents of ./google-cloud-sdk/VERSION in {{ gcloud_archive_path }}
       ansible.builtin.slurp:
@@ -16,22 +18,21 @@
       register: gcloud_installed_version_data
     - name: gcloud | Archive | Setting the gcloud_installed_version variable/fact
       ansible.builtin.set_fact:
-        gcloud_installed_version: "{{ (gcloud_installed_version_data.content|b64decode|trim) }}"
+        gcloud_installed_version: "{{ (gcloud_installed_version_data.content | b64decode | trim) }}"
     - name: gcloud | Archive | get the gcloud_installed_version
       ansible.builtin.debug:
         msg: "google-cloud-sdk: {{ gcloud_installed_version }} is installed"
     - name: gcloud | Archive | Version already installed
+      when: gcloud_version == gcloud_installed_version
       ansible.builtin.debug:
         msg: >-
           Skipping installation of google-cloud-sdk version {{ gcloud_version }} when
           {{ gcloud_installed_version }} is already installed.
-      when: gcloud_version == gcloud_installed_version
-  when: gcloud_status.stat.exists
 
 - name: gcloud | Archive | Start installation
-  ansible.builtin.include_tasks: archive_install.yml
   when: gcloud_installed_version is undefined or
         gcloud_version is version(gcloud_installed_version, '>')
+  ansible.builtin.include_tasks: archive_install.yml
 
 - name: gcloud | Debian | Install the google-cloud-sdk additional components # noqa 301
   ansible.builtin.command: gcloud components install {{ item }}

--- a/roles/gcloud/tasks/main.yml
+++ b/roles/gcloud/tasks/main.yml
@@ -5,8 +5,8 @@
   vars:
     params:
       files:
-        - "os/{{ ansible_distribution|lower }}.yml"
-        - "os/{{ ansible_os_family|lower }}.yml"
+        - "os/{{ ansible_distribution | lower }}.yml"
+        - "os/{{ ansible_os_family | lower }}.yml"
         - main.yml
       paths:
         - 'vars'

--- a/roles/gcloud/tasks/package/debian.yml
+++ b/roles/gcloud/tasks/package/debian.yml
@@ -12,14 +12,18 @@
     filename: google-cloud-sdk
 
 - name: gcloud | Debian | Install the google-cloud-sdk package
-  ansible.builtin.apt: name=google-cloud-sdk update_cache=yes
+  ansible.builtin.apt:
+    name: "google-cloud-sdk"
+    update_cache: "yes"
   register: task_result
   until: task_result is success
   retries: 10
   delay: 2
 
 - name: gcloud | Debian | Install the google-cloud-sdk additional components
-  ansible.builtin.apt: name=google-cloud-sdk-{{ item }} update_cache=yes
+  ansible.builtin.apt:
+    name: "google-cloud-sdk-{{ item }}"
+    update_cache: "yes"
   register: task_result
   until: task_result is success
   retries: 10

--- a/roles/gcloud/tasks/package/main.yml
+++ b/roles/gcloud/tasks/package/main.yml
@@ -2,4 +2,4 @@
 # tasks file for gcloud
 
 - name: gcloud | Start package installation for specific distro
-  ansible.builtin.include_tasks: "{{ ansible_os_family|lower }}.yml"
+  ansible.builtin.include_tasks: "{{ ansible_os_family | lower }}.yml"

--- a/roles/gcloud/tasks/package/redhat.yml
+++ b/roles/gcloud/tasks/package/redhat.yml
@@ -13,14 +13,18 @@
       - https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 
 - name: gcloud | RHEL | Install the google-cloud-sdk package
-  ansible.builtin.yum: name=google-cloud-sdk update_cache=yes
+  ansible.builtin.yum:
+    name: "google-cloud-sdk"
+    update_cache: "yes"
   register: task_result
   until: task_result is success
   retries: 10
   delay: 2
 
 - name: gcloud | Debian | Install the google-cloud-sdk additional components
-  ansible.builtin.yum: name=google-cloud-sdk-{{ item }} update_cache=yes
+  ansible.builtin.yum:
+    name: "google-cloud-sdk-{{ item }}"
+    update_cache: "yes"
   register: task_result
   until: task_result is success
   retries: 10

--- a/roles/gcsfuse/meta/main.yml
+++ b/roles/gcsfuse/meta/main.yml
@@ -1,8 +1,8 @@
 ---
 galaxy_info:
-  role_name: gcloud
+  role_name: gcsfuse
   author: Eric Anderson
-  description: Ansible role to install google-cloud-sdk
+  description: Ansible role to install gcsfuse
   license: GPL-3.0
   min_ansible_version: "2.9"
   platforms:
@@ -15,6 +15,6 @@ galaxy_info:
   galaxy_tags:
     - gcloud
     - google
-    - cloud
-    - sdk
+    - gcsfuse
+    - fuse
 dependencies: []

--- a/roles/gcsfuse/tasks/debian.yml
+++ b/roles/gcsfuse/tasks/debian.yml
@@ -1,6 +1,7 @@
 ---
 - name: gcsfuse | Ensure gpg is installed
-  ansible.builtin.apt: name=gnupg
+  ansible.builtin.apt:
+    name: "gnupg"
   register: task_result
   until: task_result is success
   retries: 10
@@ -18,7 +19,9 @@
     filename: gcsfuse
 
 - name: gcsfuse | Install gcsfuse
-  ansible.builtin.apt: name=gcsfuse update_cache=yes
+  ansible.builtin.apt:
+    name: "gcsfuse"
+    update_cache: "yes"
   register: task_result
   until: task_result is success
   retries: 10

--- a/roles/gcsfuse/tasks/main.yml
+++ b/roles/gcsfuse/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
 # tasks file for google.cloud.gcsfuse
-- name: main
-  ansible.builtin.include_tasks: "{{ ansible_os_family|lower }}.yml"
+- name: Main
+  ansible.builtin.include_tasks: "{{ ansible_os_family | lower }}.yml"


### PR DESCRIPTION
Ansible-lint is required for Ansible collection
certification for Automation Hub.

gcsfuse had no metadata associated with it, failing the Ansible Hub upload.
