### PR TITLE
tests: add sanity tests for python 2.7

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -21,11 +21,20 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      # Automation-hub requires python2.7 sanity tests
+      - name: setup python2.7
+        run: |
+          sudo apt-add-repository universe
+          sudo apt update
+          sudo apt install python2.7
+          curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
+          sudo /usr/bin/python2.7 get-pip.py
+          pip2 install virtualenv
       - name: Install ansible-base (${{ matrix.ansible_version }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible_version }}.tar.gz --disable-pip-version-check
       - name: Run ansible-test sanity
         # validate-modules cannot be turned on until #498 is resolved.
-        run: ansible-test sanity -v --color --python "$PYTHON_VERSION" --skip validate-modules
+        run: ansible-test sanity -v --color --skip validate-modules
       - name: Install ansible-lint
         run: pip install ansible-lint
       - name: Run ansible-lint
@@ -48,7 +57,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: "${{ env.PYTHON_VERSION }}"
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Install test dependencies

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Google.Cloud Release Notes
 .. contents:: Topics
 
 
+v1.1.1
+======
+
+Bugfixes
+--------
+
+- fix collection to work with Python 2.7
+
 v1.1.0
 ======
 
@@ -23,5 +31,6 @@ Bugfixes
 - gcp_container_cluster - support GKE clusters greater than 1.19+, which cannot use basic-auth.
 - gcp_crypto_key - skip_initial_version_creation defaults to the correct value.
 - gcp_iam_role - now properly undeletes and recognizes soft deleted roles as absent.
+- gcp_iam_role - update of a role is functional (GitHub
 - gcp_spanner_database - recognize a non-existent resource as absent.
 - gcp_storage_object - fix for correct version of dependency requirement.

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -6,6 +6,7 @@ plugins:
   callback: {}
   cliconf: {}
   connection: {}
+  filter: {}
   httpapi: {}
   inventory:
     gcp_compute:
@@ -867,5 +868,6 @@ plugins:
   netconf: {}
   shell: {}
   strategy: {}
+  test: {}
   vars: {}
-version: 1.1.0-beta.0
+version: 1.1.1

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -14,13 +14,20 @@ releases:
       - gcp_crypto_key - skip_initial_version_creation defaults to the correct value.
       - gcp_iam_role - now properly undeletes and recognizes soft deleted roles as
         absent.
+      - gcp_iam_role - update of a role is functional (GitHub
       - gcp_spanner_database - recognize a non-existent resource as absent.
       - gcp_storage_object - fix for correct version of dependency requirement.
-      - gcp_iam_role - update of a role is functional (GitHub #236).
       minor_changes:
       - GCE inventory plugin - a new option ``name_suffix``, to add a suffix to the
         name parameter.
     fragments:
     - 0001_disk.yml
     - bugfixes.yaml
+    release_date: '2022-12-16'
+  1.1.1:
+    changes:
+      bugfixes:
+      - fix collection to work with Python 2.7
+    fragments:
+    - fix-2.7.yml
     release_date: '2022-12-16'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: google
 name: cloud
 
 # The version of the collection. Must be compatible with semantic versioning
-version: "1.1.0"
+version: "1.1.1"
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/module_utils/gcp_utils.py
+++ b/plugins/module_utils/gcp_utils.py
@@ -112,7 +112,7 @@ class GcpSession(object):
         This method should be avoided in favor of full_put
         """
         kwargs = {'json': body}
-        return self.full_put(url, **kwargs, params=params)
+        return self.full_put(url, params=params, **kwargs)
 
     def patch(self, url, body=None, **kwargs):
         """


### PR DESCRIPTION
Automation Hub still runs sanity tests on python 2.7

updating release to 1.1.1 to publish a new version.
