### PR TITLE
re-add gcp_compute as a valid plugin name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Google.Cloud Release Notes
 .. contents:: Topics
 
 
+v1.1.2
+======
+
+Bugfixes
+--------
+
+- fix `gcp_compute` no longer being a valid name of the inventory plugin
+
 v1.1.1
 ======
 

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -870,4 +870,4 @@ plugins:
   strategy: {}
   test: {}
   vars: {}
-version: 1.1.1
+version: 1.1.2

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -31,3 +31,10 @@ releases:
     fragments:
     - fix-2.7.yml
     release_date: '2022-12-16'
+  1.1.2:
+    changes:
+      bugfixes:
+      - fix `gcp_compute` no longer being a valid name of the inventory plugin
+    fragments:
+    - fix-inventory-plugin.yml
+    release_date: '2022-12-21'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: google
 name: cloud
 
 # The version of the collection. Must be compatible with semantic versioning
-version: "1.1.1"
+version: "1.1.2"
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/inventory/gcp_compute.py
+++ b/plugins/inventory/gcp_compute.py
@@ -22,7 +22,7 @@ DOCUMENTATION = """
         plugin:
             description: token that ensures this is a source file for the 'gcp_compute' plugin.
             required: True
-            choices: ['google.cloud.gcp_compute']
+            choices: ['google.cloud.gcp_compute', 'gcp_compute']
         zones:
           description: A list of regions in which to describe GCE instances.
                        If none provided, it defaults to all zones available to a given project.


### PR DESCRIPTION
commit ccbde5f93e76404a5165a675a38cf2e1b83b4794 introduced a backwards-incompatible change which made ansible-inventory no longer recognize `gcp_compute` as a valid package name.

This would break users who are use `gcp_compute` (instead of the new `google.cloud.gcp_compute`). Accepting both until at least a major version change.

fixes #536.