### PR TITLE
Improve error handling for auth_kind serviceaccount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tests/integration/inventory
 tests/output/
 __pycache__
 *.tar.gz
+venv/


### PR DESCRIPTION
Fixes ansible-collections/google.cloud#538.

##### SUMMARY
* When the `auth_type` is "serviceaccount", but neither `service_account_file` or `service_account_contents` are set, an error message clearly stating this will be issues, instead of a misleading "not implemented" error.
* When service account contents fail to parse as JSON, a hint is now given as to why that happened.
* Instead of checking if a service account file doesn't exist, but propagating all other file read errors unhandled, we now check for _all_ `OSError`s that can be generated by the underlying call to `io.open` and indicate what happened.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`gcp_utils.py`