### PR TITLE
Update example inventory filter

### DIFF
--- a/plugins/inventory/gcp_compute.py
+++ b/plugins/inventory/gcp_compute.py
@@ -125,8 +125,8 @@ projects:
   - gcp-prod-gke-100
   - gcp-cicd-101
 filters:
-  - machineType = n1-standard-1
-  - scheduling.automaticRestart = true AND machineType = n1-standard-1
+  - status = RUNNING
+  - scheduling.automaticRestart = true AND status = RUNNING
 service_account_file: /tmp/service_account.json
 auth_kind: serviceaccount
 scopes:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Update the example inventory filter to not use a machineType filter. The existing machineType filter example is erroneous, see
https://github.com/ansible-collections/google.cloud/issues/421#issuecomment-1361680826 Change the filter to use "status = RUNNING"

Seeing a broken reference examples in the documentation is very confusing to users.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gcp_compute_inventory docs