### PR TITLE
chore: pin ansible-lint to 6.13.1

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -36,7 +36,7 @@ jobs:
         # validate-modules cannot be turned on until #498 is resolved.
         run: ansible-test sanity -v --color --skip validate-modules
       - name: Install ansible-lint
-        run: pip install ansible-lint
+        run: pip install ansible-lint==6.13.1
       - name: Run ansible-lint
         run: ansible-lint
   unit:

--- a/.github/workflows/gcloud.yml
+++ b/.github/workflows/gcloud.yml
@@ -30,10 +30,10 @@ jobs:
         with:
           path: ansible_collections/google/cloud
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/gcsfuse.yml
+++ b/.github/workflows/gcsfuse.yml
@@ -25,10 +25,10 @@ jobs:
         with:
           path: ansible_collections/google/cloud
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install dependencies
         run: |

--- a/roles/gcloud/tasks/archive/archive_install.yml
+++ b/roles/gcloud/tasks/archive/archive_install.yml
@@ -1,18 +1,18 @@
 ---
-- name: gcloud | Archive | Ensure temp path exists
+- name: Gcloud | Archive | Ensure temp path exists
   ansible.builtin.file:
     path: "{{ gcloud_archive_path }}"
     state: "directory"
     mode: "0755"
 
-- name: gcloud | Archive | Extract Cloud SDK archive
+- name: Gcloud | Archive | Extract Cloud SDK archive
   ansible.builtin.unarchive:
     src: "{{ gcloud_archive_url }}"
     dest: "{{ gcloud_archive_path }}"
     remote_src: yes
     creates: "{{ gcloud_library_path }}"
 
-- name: gcloud | Archive | Link binaries to /usr/bin (like package install)
+- name: Gcloud | Archive | Link binaries to /usr/bin (like package install)
   ansible.builtin.file:
     src: "{{ gcloud_library_path }}/bin/{{ item }}"
     dest: "/usr/bin/{{ item }}"
@@ -25,11 +25,12 @@
     - gsutil
   when: not gcloud_install_script
 
-- name: gcloud | Archive | Add command completion
+- name: Gcloud | Archive | Add command completion
   ansible.builtin.include_tasks: command_completion.yml
   when: gcloud_command_completion
 
-- name: gcloud | Archive | Install into Path
+- name: Gcloud | Archive | Install into Path
+  changed_when: false
   ansible.builtin.command: >-
     {{ gcloud_archive_path }}/install.sh --quiet
     --usage-reporting {{ gcloud_usage_reporting | lower }}

--- a/roles/gcloud/tasks/archive/command_completion.yml
+++ b/roles/gcloud/tasks/archive/command_completion.yml
@@ -1,6 +1,6 @@
 ---
 # task file to configure bash completion for gcloud
-- name: gcloud | Archive | Debian | Ensure bash completion is installed
+- name: Gcloud | Archive | Debian | Ensure bash completion is installed
   ansible.builtin.apt:
     name: "bash-completion"
   register: task_result
@@ -9,7 +9,7 @@
   delay: 2
   when: ansible_os_family == "Debian"
 
-- name: gcloud | Archive | RedHat | Ensure bash completion is installed
+- name: Gcloud | Archive | RedHat | Ensure bash completion is installed
   ansible.builtin.yum:
     name:
       - bash-completion
@@ -19,7 +19,7 @@
   delay: 2
   when: ansible_os_family == "RedHat"
 
-- name: gcloud | Archive | Ensure bash_completion.d directory exists
+- name: Gcloud | Archive | Ensure bash_completion.d directory exists
   ansible.builtin.file:
     path: /etc/bash_completion.d
     owner: root
@@ -27,7 +27,7 @@
     state: directory
     mode: 0755
 
-- name: gcloud | Archive | Link binaries to /usr/bin (like package install)
+- name: Gcloud | Archive | Link binaries to /usr/bin (like package install)
   ansible.builtin.file:
     src: "{{ gcloud_library_path }}/completion.bash.inc"
     dest: /etc/bash_completion.d/gcloud

--- a/roles/gcloud/tasks/archive/main.yml
+++ b/roles/gcloud/tasks/archive/main.yml
@@ -1,40 +1,40 @@
 ---
 # tasks to install gcloud via archive
-- name: gcloud | Archive | Look for existing Google Cloud SDK installation
+- name: Gcloud | Archive | Look for existing Google Cloud SDK installation
   ansible.builtin.stat:
     path: "{{ gcloud_archive_path }}/google-cloud-sdk/VERSION"
   register: gcloud_status
 
-- name: gcloud | Archive | Get gcloud_status
+- name: Gcloud | Archive | Get gcloud_status
   ansible.builtin.debug:
     var: "gcloud_status"
 
-- name: gcloud | Archive | Set installed version if installation exists
+- name: Gcloud | Archive | Set installed version if installation exists
   when: gcloud_status.stat.exists
   block:
-    - name: gcloud | Archive | Importing contents of ./google-cloud-sdk/VERSION in {{ gcloud_archive_path }}
+    - name: Gcloud | Archive | Importing contents of ./google-cloud-sdk/VERSION in {{ gcloud_archive_path }}
       ansible.builtin.slurp:
         src: "{{ gcloud_archive_path }}/google-cloud-sdk/VERSION"
       register: gcloud_installed_version_data
-    - name: gcloud | Archive | Setting the gcloud_installed_version variable/fact
+    - name: Gcloud | Archive | Setting the gcloud_installed_version variable/fact
       ansible.builtin.set_fact:
         gcloud_installed_version: "{{ (gcloud_installed_version_data.content | b64decode | trim) }}"
-    - name: gcloud | Archive | get the gcloud_installed_version
+    - name: Gcloud | Archive | get the gcloud_installed_version
       ansible.builtin.debug:
         msg: "google-cloud-sdk: {{ gcloud_installed_version }} is installed"
-    - name: gcloud | Archive | Version already installed
+    - name: Gcloud | Archive | Version already installed
       when: gcloud_version == gcloud_installed_version
       ansible.builtin.debug:
         msg: >-
           Skipping installation of google-cloud-sdk version {{ gcloud_version }} when
           {{ gcloud_installed_version }} is already installed.
 
-- name: gcloud | Archive | Start installation
+- name: Gcloud | Archive | Start installation
   when: gcloud_installed_version is undefined or
         gcloud_version is version(gcloud_installed_version, '>')
   ansible.builtin.include_tasks: archive_install.yml
 
-- name: gcloud | Debian | Install the google-cloud-sdk additional components # noqa 301
+- name: Gcloud | Debian | Install the google-cloud-sdk additional components # noqa 301
   ansible.builtin.command: gcloud components install {{ item }}
   register: gcloud_install_comp_status
   changed_when: "'All components are up to date.' not in gcloud_install_comp_status.stderr_lines"

--- a/roles/gcloud/tasks/main.yml
+++ b/roles/gcloud/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: gcloud | Load Distro and OS specific variables
+- name: Gcloud | Load Distro and OS specific variables
   ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
   vars:
     params:
@@ -11,5 +11,5 @@
       paths:
         - 'vars'
 
-- name: gcloud | Install the google-cloud-sdk from {{ gcloud_install_type }}
+- name: Gcloud | Install the google-cloud-sdk from {{ gcloud_install_type }}
   ansible.builtin.include_tasks: "{{ gcloud_install_type }}/main.yml"

--- a/roles/gcloud/tasks/package/debian.yml
+++ b/roles/gcloud/tasks/package/debian.yml
@@ -1,17 +1,17 @@
 ---
 # tasks that install gcloud on debian
-- name: gcloud | Debian | Add an Apt signing key, uses whichever key is at the URL
+- name: Gcloud | Debian | Add an Apt signing key, uses whichever key is at the URL
   ansible.builtin.apt_key:
     url: "{{ gcloud_apt_key }}"
     state: present
 
-- name: gcloud | Debian | Add the gcloud repository
+- name: Gcloud | Debian | Add the gcloud repository
   ansible.builtin.apt_repository:
     repo: "deb {{ gcloud_apt_url }} {{ gcloud_apt_repo }} main"
     state: present
     filename: google-cloud-sdk
 
-- name: gcloud | Debian | Install the google-cloud-sdk package
+- name: Gcloud | Debian | Install the google-cloud-sdk package
   ansible.builtin.apt:
     name: "google-cloud-sdk"
     update_cache: "yes"
@@ -20,7 +20,7 @@
   retries: 10
   delay: 2
 
-- name: gcloud | Debian | Install the google-cloud-sdk additional components
+- name: Gcloud | Debian | Install the google-cloud-sdk additional components
   ansible.builtin.apt:
     name: "google-cloud-sdk-{{ item }}"
     update_cache: "yes"

--- a/roles/gcloud/tasks/package/main.yml
+++ b/roles/gcloud/tasks/package/main.yml
@@ -1,5 +1,5 @@
 ---
 # tasks file for gcloud
 
-- name: gcloud | Start package installation for specific distro
+- name: Gcloud | Start package installation for specific distro
   ansible.builtin.include_tasks: "{{ ansible_os_family | lower }}.yml"

--- a/roles/gcloud/tasks/package/redhat.yml
+++ b/roles/gcloud/tasks/package/redhat.yml
@@ -1,9 +1,8 @@
 ---
-- name: gcloud | RHEL | Add an Apt signing key, uses whichever key is at the URL
+- name: Gcloud | RHEL | Add an Apt signing key, uses whichever key is at the URL
   ansible.builtin.yum_repository:
     name: google-cloud-sdk
     description: Google Cloud SDK
-    ansible.builtin.file: google-cloud-sdk
     baseurl: https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
     enabled: yes
     gpgcheck: yes
@@ -12,7 +11,7 @@
       - https://packages.cloud.google.com/yum/doc/yum-key.gpg
       - https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 
-- name: gcloud | RHEL | Install the google-cloud-sdk package
+- name: Gcloud | RHEL | Install the google-cloud-sdk package
   ansible.builtin.yum:
     name: "google-cloud-sdk"
     update_cache: "yes"
@@ -21,7 +20,7 @@
   retries: 10
   delay: 2
 
-- name: gcloud | Debian | Install the google-cloud-sdk additional components
+- name: Gcloud | Debian | Install the google-cloud-sdk additional components
   ansible.builtin.yum:
     name: "google-cloud-sdk-{{ item }}"
     update_cache: "yes"

--- a/roles/gcsfuse/tasks/debian.yml
+++ b/roles/gcsfuse/tasks/debian.yml
@@ -1,5 +1,5 @@
 ---
-- name: gcsfuse | Ensure gpg is installed
+- name: Gcsfuse | Ensure gpg is installed
   ansible.builtin.apt:
     name: "gnupg"
   register: task_result
@@ -7,18 +7,18 @@
   retries: 10
   delay: 2
 
-- name: gcsfuse | Add an apt signing key
+- name: Gcsfuse | Add an apt signing key
   ansible.builtin.apt_key:
     url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
     state: present
 
-- name: gcsfuse | Add the apt repository
+- name: Gcsfuse | Add the apt repository
   ansible.builtin.apt_repository:
     repo: deb http://packages.cloud.google.com/apt gcsfuse-{{ ansible_distribution_release }} main
     state: present
     filename: gcsfuse
 
-- name: gcsfuse | Install gcsfuse
+- name: Gcsfuse | Install gcsfuse
   ansible.builtin.apt:
     name: "gcsfuse"
     update_cache: "yes"


### PR DESCRIPTION
ansible-lint was updated and the GitHub
action did not pin the dependency, resulting
in the repository to fail sanity tests.

Updating the repository to adhere to new fatal
linter rules, but also pinning the linter to
prevent failures that may be unrelated to the
particular commit.