### PR TITLE
Fix bug to handle duplicate subnet across different vpc networks

### DIFF
--- a/plugins/modules/gcp_compute_subnetwork.py
+++ b/plugins/modules/gcp_compute_subnetwork.py
@@ -317,6 +317,7 @@ from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import (
 )
 import json
 import time
+import ipaddress
 
 ################################################################################
 # Main
@@ -353,7 +354,10 @@ def main():
 
     if fetch:
         if state == 'present':
-            if is_different(module, fetch):
+            if module.params['network']['selfLink'] != fetch['network']: # found difference on same subnet within the same VPC network
+                module.fail_json(msg="Subnet already exists in a different VPC network: %s, please change the name or region" % fetch['network'])
+                changed = False
+            elif is_different(module, fetch):
                 update(module, self_link(module), kind, fetch)
                 fetch = fetch_resource(module, self_link(module), kind)
                 changed = True

--- a/plugins/modules/gcp_compute_subnetwork.py
+++ b/plugins/modules/gcp_compute_subnetwork.py
@@ -355,7 +355,7 @@ def main():
     if fetch:
         if state == 'present':
             if module.params['network']['selfLink'] != fetch['network']: # found difference on same subnet within the same VPC network
-                module.fail_json(msg="Subnet already exists in a different VPC network: %s, please change the name or region" % fetch['network'])
+                module.fail_json(msg="Subnet already exists in a different VPC network: %s" % fetch['network'])
                 changed = False
             elif is_different(module, fetch):
                 update(module, self_link(module), kind, fetch)

--- a/plugins/modules/gcp_compute_subnetwork.py
+++ b/plugins/modules/gcp_compute_subnetwork.py
@@ -317,7 +317,7 @@ from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import (
 )
 import json
 import time
-import ipaddress
+
 
 ################################################################################
 # Main


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
GCP doesn't allow to create any subnet with the same name in the same region if already exists in any other VPC network, but the original ansible module gcp_compute_subnetwork doesn't throw an error. So this PR suggests adding a condition check in the module and error out for this scenario.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #560 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/modules/gcp_compute_subnetwork.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
GCP API will throw an error if found a duplicated subnet name on another vpc when you are trying to create a same-name subnet. Refer the API guide for details. https://cloud.google.com/compute/docs/reference/rest/v1/subnetworks/insert
This PR suggests adding a condition check to error out the above-mentioned scenario, by comparing the intended vpc network in the request vs the vpc found for the existing subnet,  and throw an error if it's a different vpc network.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
After this suggested change, A fatal error will occur to handle the above-mentioned case. Which tells the user to either change the subnet name to unique or change to a different region.
```
