### PR TITLE
Updating gcp_container_cluster.py, adding support for ip_allocation_policy->stack_type and network_config->datapath_provider

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: google
 name: cloud
 
 # The version of the collection. Must be compatible with semantic versioning
-version: "1.1.4"
+version: "1.1.3"
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md
@@ -17,8 +17,9 @@ readme: README.md
 # A list of the collection's content authors. Can be just the name or in the format 'Full Name <email> (url)
 # @nicks:irc/im.site#channel'
 authors:
-    - Google <alexstephen@google.com>
-    - Google <yusuketsutsumi@google.com>
+- Google <alexstephen@google.com>
+- Google <yusuketsutsumi@google.com>
+
 
 ### OPTIONAL but strongly recommended
 
@@ -28,7 +29,7 @@ description: The Google Cloud Platform collection.
 # Either a single license or a list of licenses for content inside of a collection. Ansible Galaxy currently only
 # accepts L(SPDX,https://spdx.org/licenses/) licenses. This key is mutually exclusive with 'license_file'
 license:
-    - GPL-2.0-or-later
+- GPL-2.0-or-later
 
 # The path to the license file for the collection. This path is relative to the root of the collection. This key is
 # mutually exclusive with 'license'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: google
 name: cloud
 
 # The version of the collection. Must be compatible with semantic versioning
-version: "1.1.3"
+version: "1.1.4"
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md
@@ -17,9 +17,8 @@ readme: README.md
 # A list of the collection's content authors. Can be just the name or in the format 'Full Name <email> (url)
 # @nicks:irc/im.site#channel'
 authors:
-- Google <alexstephen@google.com>
-- Google <yusuketsutsumi@google.com>
-
+    - Google <alexstephen@google.com>
+    - Google <yusuketsutsumi@google.com>
 
 ### OPTIONAL but strongly recommended
 
@@ -29,7 +28,7 @@ description: The Google Cloud Platform collection.
 # Either a single license or a list of licenses for content inside of a collection. Ansible Galaxy currently only
 # accepts L(SPDX,https://spdx.org/licenses/) licenses. This key is mutually exclusive with 'license_file'
 license:
-- GPL-2.0-or-later
+    - GPL-2.0-or-later
 
 # The path to the license file for the collection. This path is relative to the root of the collection. This key is
 # mutually exclusive with 'license'

--- a/plugins/modules/gcp_container_cluster.py
+++ b/plugins/modules/gcp_container_cluster.py
@@ -552,6 +552,11 @@ options:
         - Set to /netmask (e.g. /14) to have a range chosen with a specific netmask.
         required: false
         type: str
+      stack_type:
+        description:
+          - The IP stack type of the cluster, possible values: (STACK_TYPE_UNSPECIFIED, IPV4, IPV4_IPV6)
+        required: false
+        type: str
   initial_cluster_version:
     description:
     - The software version of the master endpoint and kubelets used in the cluster
@@ -1257,6 +1262,11 @@ ipAllocationPolicy:
       - Set to /netmask (e.g. /14) to have a range chosen with a specific netmask.
       returned: success
       type: str
+    stackType:
+      description:
+        - The IP stack type of the cluster, possible values: (STACK_TYPE_UNSPECIFIED, IPV4, IPV4_IPV6)
+      type: str
+      returned: success
 endpoint:
   description:
   - The IP address of this cluster's master endpoint.
@@ -1564,6 +1574,7 @@ def main():
                     node_ipv4_cidr_block=dict(type='str'),
                     services_ipv4_cidr_block=dict(type='str'),
                     tpu_ipv4_cidr_block=dict(type='str'),
+                    stack_type=dict(type='str'),
                 ),
             ),
             initial_cluster_version=dict(type='str'),
@@ -2253,6 +2264,7 @@ class ClusterIpallocationpolicy(object):
                 u'nodeIpv4CidrBlock': self.request.get('node_ipv4_cidr_block'),
                 u'servicesIpv4CidrBlock': self.request.get('services_ipv4_cidr_block'),
                 u'tpuIpv4CidrBlock': self.request.get('tpu_ipv4_cidr_block'),
+                u'stackType': self.request.get('stack_type'),
             }
         )
 

--- a/plugins/modules/gcp_container_cluster.py
+++ b/plugins/modules/gcp_container_cluster.py
@@ -628,6 +628,11 @@ options:
     required: false
     type: dict
     suboptions:
+      datapath_provider: 
+        description:
+        - The datapath provider selects the implementation of the Kubernetes networking model for service resolution and network policy enforcement.
+        required: false
+        type: str
       enable_intra_node_visibility:
         description:
         - Whether Intra-node visibility is enabled for this cluster. This makes same
@@ -1572,7 +1577,7 @@ def main():
             binary_authorization=dict(type='dict', options=dict(enabled=dict(type='bool'))),
             release_channel=dict(type='dict', options=dict(channel=dict(type='str'))),
             shielded_nodes=dict(type='dict', options=dict(enabled=dict(type='bool'))),
-            network_config=dict(type='dict', options=dict(enable_intra_node_visibility=dict(type='bool'), default_snat_status=dict(type='bool'))),
+            network_config=dict(type='dict', options=dict(enable_intra_node_visibility=dict(type='bool'), default_snat_status=dict(type='bool'), datapath_provider=dict(type='str'))),
             enable_kubernetes_alpha=dict(type='bool'),
             location=dict(required=True, type='str', aliases=['zone']),
             kubectl_path=dict(type='str'),
@@ -2422,12 +2427,12 @@ class ClusterNetworkconfig(object):
 
     def to_request(self):
         return remove_nones_from_dict(
-            {u'enableIntraNodeVisibility': self.request.get('enable_intra_node_visibility'), u'defaultSnatStatus': self.request.get('default_snat_status')}
+            {u'enableIntraNodeVisibility': self.request.get('enable_intra_node_visibility'), u'defaultSnatStatus': self.request.get('default_snat_status'), u'datapathProvider': self.request.get('datapath_provider')}
         )
 
     def from_response(self):
         return remove_nones_from_dict(
-            {u'enableIntraNodeVisibility': self.request.get(u'enableIntraNodeVisibility'), u'defaultSnatStatus': self.request.get(u'defaultSnatStatus')}
+            {u'enableIntraNodeVisibility': self.request.get(u'enableIntraNodeVisibility'), u'defaultSnatStatus': self.request.get(u'defaultSnatStatus'), u'datapathProvider': self.request.get('datapath_provider') }
         )
 
 


### PR DESCRIPTION
##### SUMMARY
Address Issue #566 

In order to be able to create an IPV6 enabled GKE cluster, you need to specify a custom network + subnetwork which is already exposed.  The other requirements are 

1. stack_type needs to be set to IPV4_IPV6 
2. the data_provider to ADVANCED_DATAPATH.



Example yaml

```yaml
    - name: create cluster
      gcp_container_cluster:
        ip_allocation_policy:
          stack_type: "IPV4_IPV6"
        network_config:
          datapath_provider: "ADVANCED_DATAPATH"
```


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
gcp_container_cluster


##### ADDITIONAL INFORMATION
