### PR TITLE
[draft] fix: use default service account if unset

### DIFF
--- a/plugins/module_utils/gcp_utils.py
+++ b/plugins/module_utils/gcp_utils.py
@@ -246,8 +246,9 @@ class GcpSession(object):
             return svc_acct_creds.with_scopes(self.module.params['scopes'])
 
         if cred_type == 'machineaccount':
-            return google.auth.compute_engine.Credentials(
-                self.module.params['service_account_email'])
+            email = self.module.params['service_account_email']
+            email = email if email is not None else "default"
+            return google.auth.compute_engine.Credentials(email)
 
         self.module.fail_json(msg="Credential type '%s' not implemented" % cred_type)
 


### PR DESCRIPTION
`service_account_email` defaults to None if one
is not set. For gcp_compute_instance_info, this results in an invalid request as the service account is populated directly in the path.

Populating `default` when a value is not set fixes the error.

fixes #568