### PR TITLE
Fix grammatical typo in google.cloud.gcp_compute inventory documentation

### DIFF
--- a/plugins/inventory/gcp_compute.py
+++ b/plugins/inventory/gcp_compute.py
@@ -39,7 +39,7 @@ DOCUMENTATION = """
           description: >
             A list of filter value pairs. Available filters are listed here
             U(https://cloud.google.com/compute/docs/reference/rest/v1/instances/aggregatedList).
-            Each additional filter in the list will act be added as an AND condition
+            Each additional filter in the list will be added as an AND condition
             (filter1 and filter2)
           type: list
         hostnames:


### PR DESCRIPTION
##### SUMMARY
Fixes grammatical typo in [google.cloud.gcp_compute inventory documentation](https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_compute_inventory.html) 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Google Cloud Compute Engine inventory plugin
