### PR TITLE
fix: check for labels in json dict when using them for hostnames

### DIFF
--- a/plugins/inventory/gcp_compute.py
+++ b/plugins/inventory/gcp_compute.py
@@ -237,7 +237,8 @@ class GcpInstance(object):
         for order in self.hostname_ordering:
             name = None
             if order.startswith("labels."):
-                name = self.json["labels"].get(order[7:])
+                if "labels" in self.json:
+                    name = self.json["labels"].get(order[7:])
             elif order == "public_ip":
                 name = self._get_publicip()
             elif order == "private_ip":


### PR DESCRIPTION
##### SUMMARY

If there is an instance in the inventory without any labels, the labels key won't be present in `self.json`



##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
google.cloud

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
This will happen under the following conditions:
- labels are set to be used first for the hostname like this: `hostnames: ['labels.ansible_deploy_name', 'name', 'private_ip']`
- an instance exists in your inventory without any labels

Here is an example of the error you get when doing a `ansible-inventory --graph -i gcp_compute.yml`

```
[WARNING]:  * Failed to parse /Users/jarv/workspace/gl-infra/deployer/deploy-tooling/gcp_compute.yml with
ansible_collections.google.cloud.plugins.inventory.gcp_compute plugin: 'labels'
  File "/Users/jarv/.local/share/virtualenvs/deploy-tooling-qAV_wwNo/lib/python3.7/site-packages/ansible/inventory/manager.py", line 280, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/Users/jarv/.ansible/collections/ansible_collections/google/cloud/plugins/inventory/gcp_compute.py", line 622, in parse
    self._add_hosts(value, config_data, project_disks=project_disks)
  File "/Users/jarv/.ansible/collections/ansible_collections/google/cloud/plugins/inventory/gcp_compute.py", line 441, in _add_hosts
    self._populate_host(host)
  File "/Users/jarv/.ansible/collections/ansible_collections/google/cloud/plugins/inventory/gcp_compute.py", line 308, in _populate_host
    hostname = item.hostname()
  File "/Users/jarv/.ansible/collections/ansible_collections/google/cloud/plugins/inventory/gcp_compute.py", line 240, in hostname
    name = self.json["labels"].get(order[7:])
[WARNING]: Unable to parse /Users/jarv/workspace/gl-infra/deployer/deploy-tooling/gcp_compute.yml as an inventory
source
[WARNING]: No inventory was parsed, only implicit localhost is available
```
