### PR TITLE
fix: don't send empty arguments to gcloud in the cleanup script

### DIFF
--- a/scripts/cleanup-project.sh
+++ b/scripts/cleanup-project.sh
@@ -40,8 +40,20 @@ cleanup_resource() {
     extra_list_arg="$3"
     extra_delete_arg="$4"
 
-    for resource_id in $(gcloud "${resource_group}" "${resource}" list --project="${PROJECT_ID}" --format="csv[no-heading](name)" "${extra_list_arg}"); do
-        gcloud "${resource_group}" "${resource}" delete "${resource_id}" --project="${PROJECT_ID}" -q "${extra_delete_arg}"
+    if [ -z "$extra_list_arg" ]
+    then
+        resources=( $(gcloud "${resource_group}" "${resource}" list --project="${PROJECT_ID}" --format="csv[no-heading](name)") )
+    else
+        resources=( $(gcloud "${resource_group}" "${resource}" list --project="${PROJECT_ID}" --format="csv[no-heading](name)" "${extra_list_arg}") )
+    fi
+
+    for resource_id in $resources; do
+        if [ -z "$extra_delete_arg" ]
+        then
+            gcloud "${resource_group}" "${resource}" delete "${resource_id}" --project="${PROJECT_ID}" -q
+        else
+            gcloud "${resource_group}" "${resource}" delete "${resource_id}" --project="${PROJECT_ID}" -q "${extra_delete_arg}"
+        fi
     done
 }
 


### PR DESCRIPTION
##### SUMMARY
When the `scripts/cleanup-project.sh` calls `cleanup_resource()` with an empty value for either `$extra_list_arg` or `$extra_delete_arg` it will in turn call `gcloud` with the empty argument, which gets misinterpreted.

For instance, the script cleans up target http proxies with:

```
cleanup_resource "compute" "target-http-proxies" "" "--global"
```

The empty list argument is quoted in the call to `gcloud` (as it should be!), which means that the arguments that `gcloud` processes are `['gcloud', 'compute', 'target-http-proxies', 'list', '--project="blahblah"', '--format="csv[no-heading](name)"', '']`

That last empty string argument is the reason for these log messages:

```
WARNING: Argument `NAME` is deprecated. Use `--filter="name=( 'NAME' ... )"` instead.
```

And it's the reason that the script ultimately fails, as no resources are listed thus no resources are deleted.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

##### ADDITIONAL INFORMATION
