### PR TITLE
Update roles/google_cloud_ops_agents submodule to 1.0.7.

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ansible_collections/google/cloud
+          submodules: 'true'
       - name: Set up Python
         uses: actions/setup-python@v1
         with:


### PR DESCRIPTION
##### SUMMARY
This reintroduces the `roles/google_cloud_ops_agents` submodule that was unintentionally removed in #529. This also updates the role to the latest release, [1.0.7](https://github.com/GoogleCloudPlatform/google-cloud-ops-agents-ansible/releases/tag/1.0.7).

##### ISSUE TYPE
- Bug fix

##### COMPONENT NAME
google_cloud_ops_agents role

##### ADDITIONAL INFORMATION
N/A