### PR TITLE
chore: update GitHub actions to their latest versions

### DIFF
--- a/.github/workflows/ansible-integration-tests.yml
+++ b/.github/workflows/ansible-integration-tests.yml
@@ -23,13 +23,13 @@ jobs:
           - stable-2.13
     steps:
       - name: check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: ansible_collections/google/cloud
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
-          python-version: '3.9'  # this is the minimum version required for Ansible 2.13
+          python-version: '3.9'  # this is the minimum version required for Ansible 2.15
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Install ansible-base (${{ matrix.ansible_version }})

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -1,7 +1,7 @@
 name: "Run tests for the cloud.google collection"
 on: [pull_request]
 env:
-  PYTHON_VERSION: "3.9" # minimum version for Ansible 2.14
+  PYTHON_VERSION: "3.9" # minimum version for Ansible 2.15
 jobs:
   sanity-and-lint:
     runs-on: ubuntu-latest
@@ -14,11 +14,11 @@ jobs:
           - stable-2.14
     steps:
       - name: check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: ansible_collections/google/cloud
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       # Automation-hub requires python2.7 sanity tests
@@ -51,11 +51,11 @@ jobs:
           - stable-2.11
     steps:
       - name: check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: ansible_collections/google/cloud
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
       - name: Install dependencies

--- a/.github/workflows/automationhub.yml
+++ b/.github/workflows/automationhub.yml
@@ -8,9 +8,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/gcloud.yml
+++ b/.github/workflows/gcloud.yml
@@ -47,7 +47,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y docker-ce docker-ce-cli containerd.io
           python -m pip install --upgrade pip
-          pip install molecule[docker] yamllint ansible ansible-lint docker
+          pip install molecule-plugins[docker] yamllint ansible ansible-lint docker
 
       - name: Run role test
         run: >-

--- a/.github/workflows/gcloud.yml
+++ b/.github/workflows/gcloud.yml
@@ -26,12 +26,12 @@ jobs:
           - gcloud
     steps:
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
         with:
           path: ansible_collections/google/cloud
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/.github/workflows/gcloud.yml
+++ b/.github/workflows/gcloud.yml
@@ -12,7 +12,7 @@ on:
       - 'molecule/gcloud/**'
 jobs:
   molecule:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       PY_COLORS: 1
       ANSIBLE_FORCE_COLOR: 1

--- a/.github/workflows/gcloud.yml
+++ b/.github/workflows/gcloud.yml
@@ -50,6 +50,7 @@ jobs:
           pip install molecule-plugins[docker] yamllint ansible ansible-lint docker
 
       - name: Run role test
+        working-directory: ansible_collections/google/cloud
         run: >-
           molecule --version &&
           ansible --version &&

--- a/.github/workflows/gcsfuse.yml
+++ b/.github/workflows/gcsfuse.yml
@@ -42,7 +42,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y docker-ce docker-ce-cli containerd.io
           python -m pip install --upgrade pip
-          pip install molecule[docker] yamllint ansible ansible-lint docker
+          pip install molecule-plugins[docker] yamllint ansible ansible-lint docker
 
       - name: Run role test
         run: >-

--- a/.github/workflows/gcsfuse.yml
+++ b/.github/workflows/gcsfuse.yml
@@ -45,6 +45,7 @@ jobs:
           pip install molecule-plugins[docker] yamllint ansible ansible-lint docker
 
       - name: Run role test
+        working-directory: ansible_collections/google/cloud
         run: >-
           molecule --version &&
           ansible --version &&

--- a/.github/workflows/gcsfuse.yml
+++ b/.github/workflows/gcsfuse.yml
@@ -21,12 +21,12 @@ jobs:
           - gcsfuse
     steps:
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
         with:
           path: ansible_collections/google/cloud
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 

--- a/.github/workflows/gcsfuse.yml
+++ b/.github/workflows/gcsfuse.yml
@@ -10,7 +10,7 @@ on:
       - .github/workflows/gcsfuse.yml
 jobs:
   gcsfuse:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       PY_COLORS: 1
       ANSIBLE_FORCE_COLOR: 1

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -8,9 +8,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,10 +124,10 @@ Run `ansible-test integration`. Currently some tests are disabled as [test are b
 ### Prequisites for role tests
 
 If you would like to use podman, you must
-install the `molecule[podman]` package in PyPI:
+install the `molecule-plugins[podman]` package in PyPI:
 
 ```
-pip install --upgrade molecule[podman]
+pip install --upgrade molecule-plugins[podman]
 ```
 
 ### Running role tests

--- a/molecule/gcloud/molecule.yml
+++ b/molecule/gcloud/molecule.yml
@@ -9,13 +9,13 @@ lint: |
   ansible-lint
 platforms:
   - name: instance
-    image: ubuntu:18.04
+    image: ubuntu:20.04
     privileged: true
     ansible.builtin.command: "/lib/systemd/systemd"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: instance
-    image: debian:9
+    image: debian:10
     privileged: true
     ansible.builtin.command: "/lib/systemd/systemd"
     volumes:

--- a/molecule/gcsfuse/molecule.yml
+++ b/molecule/gcsfuse/molecule.yml
@@ -9,13 +9,13 @@ lint: |
   ansible-lint
 platforms:
   - name: instance
-    image: ubuntu:18.04
+    image: ubuntu:20.04
     privileged: true
     ansible.builtin.command: "/lib/systemd/systemd"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: instance
-    image: debian:9
+    image: debian:10
     privileged: true
     ansible.builtin.command: "/lib/systemd/systemd"
     volumes:

--- a/roles/gcsfuse/tasks/debian.yml
+++ b/roles/gcsfuse/tasks/debian.yml
@@ -14,7 +14,7 @@
 
 - name: Gcsfuse | Add the apt repository
   ansible.builtin.apt_repository:
-    repo: deb http://packages.cloud.google.com/apt gcsfuse-{{ ansible_distribution_release }} main
+    repo: deb https://packages.cloud.google.com/apt gcsfuse-{{ ansible_distribution_release }} main
     state: present
     filename: gcsfuse
 


### PR DESCRIPTION
We're not using any new features from these actions, but the old versions are built on deprecated NodeJS releases.