### PR TITLE
chore: address cleanup script linter warnings

### DIFF
--- a/scripts/cleanup-project.sh
+++ b/scripts/cleanup-project.sh
@@ -42,12 +42,13 @@ cleanup_resource() {
 
     if [ -z "$extra_list_arg" ]
     then
-        resources=( $(gcloud "${resource_group}" "${resource}" list --project="${PROJECT_ID}" --format="csv[no-heading](name)") )
+        mapfile -t resources < <(gcloud "${resource_group}" "${resource}" list --project="${PROJECT_ID}" --format="csv[no-heading](name)")
     else
-        resources=( $(gcloud "${resource_group}" "${resource}" list --project="${PROJECT_ID}" --format="csv[no-heading](name)" "${extra_list_arg}") )
+        mapfile -t resources < <(gcloud "${resource_group}" "${resource}" list --project="${PROJECT_ID}" --format="csv[no-heading](name)" "${extra_list_arg}")
     fi
 
-    for resource_id in $resources; do
+    for resource_id in "${resources[@]}"
+    do
         if [ -z "$extra_delete_arg" ]
         then
             gcloud "${resource_group}" "${resource}" delete "${resource_id}" --project="${PROJECT_ID}" -q


### PR DESCRIPTION
The warnings were:

```
ERROR: Found 3 shellcheck issue(s) which need to be resolved:
ERROR: scripts/cleanup-project.sh:45:21: SC2207: Prefer mapfile or read -a to split command output (or quote to avoid splitting).
ERROR: scripts/cleanup-project.sh:47:21: SC2207: Prefer mapfile or read -a to split command output (or quote to avoid splitting).
ERROR: scripts/cleanup-project.sh:50:24: SC2128: Expanding an array without an index only gives the first element.
```