### PR TITLE
chore: fix gcp_sql_database integration test

### DIFF
--- a/tests/integration/targets/gcp_sql_database/tasks/autogen.yml
+++ b/tests/integration/targets/gcp_sql_database/tasks/autogen.yml
@@ -31,7 +31,7 @@
 - name: delete a database
   google.cloud.gcp_sql_database:
     name: "{{ resource_name }}"
-    charset: utf8mb4
+    charset: utf8
     instance: "{{ instance.name }}"
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
@@ -41,7 +41,7 @@
 - name: create a database
   google.cloud.gcp_sql_database:
     name: "{{ resource_name }}"
-    charset: utf8mb4
+    charset: utf8
     instance: "{{ instance.name }}"
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
@@ -69,7 +69,7 @@
 - name: create a database that already exists
   google.cloud.gcp_sql_database:
     name: "{{ resource_name }}"
-    charset: utf8mb4
+    charset: utf8
     instance: "{{ instance.name }}"
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
@@ -84,7 +84,7 @@
 - name: delete a database
   google.cloud.gcp_sql_database:
     name: "{{ resource_name }}"
-    charset: utf8mb4
+    charset: utf8
     instance: "{{ instance.name }}"
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
@@ -112,7 +112,7 @@
 - name: delete a database that does not exist
   google.cloud.gcp_sql_database:
     name: "{{ resource_name }}"
-    charset: utf8mb4
+    charset: utf8
     instance: "{{ instance.name }}"
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"

--- a/tests/integration/targets/gcp_sql_database/tasks/autogen.yml
+++ b/tests/integration/targets/gcp_sql_database/tasks/autogen.yml
@@ -31,7 +31,7 @@
 - name: delete a database
   google.cloud.gcp_sql_database:
     name: "{{ resource_name }}"
-    charset: utf8
+    charset: utf8mb4
     instance: "{{ instance.name }}"
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
@@ -41,7 +41,7 @@
 - name: create a database
   google.cloud.gcp_sql_database:
     name: "{{ resource_name }}"
-    charset: utf8
+    charset: utf8mb4
     instance: "{{ instance.name }}"
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
@@ -69,7 +69,7 @@
 - name: create a database that already exists
   google.cloud.gcp_sql_database:
     name: "{{ resource_name }}"
-    charset: utf8
+    charset: utf8mb4
     instance: "{{ instance.name }}"
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
@@ -84,7 +84,7 @@
 - name: delete a database
   google.cloud.gcp_sql_database:
     name: "{{ resource_name }}"
-    charset: utf8
+    charset: utf8mb4
     instance: "{{ instance.name }}"
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
@@ -112,7 +112,7 @@
 - name: delete a database that does not exist
   google.cloud.gcp_sql_database:
     name: "{{ resource_name }}"
-    charset: utf8
+    charset: utf8mb4
     instance: "{{ instance.name }}"
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"


### PR DESCRIPTION
For MySQL 8.x "utf8" really mean "utf8mb3" and when you request `utf8` as the `charset`, `utf8mb3` is what's returned. Thanks to that, instead of being a no-op the "create a database that already exists" test attempts to update the database and fails rather than seeing that the database exists and is in the correct configuration. The fix here is to use a valid character set (`utf8mb4 ` is the [recommended encoding](https://dev.mysql.com/doc/refman/8.0/en/charset-unicode-sets.html)).