### PR TITLE
chore: update README version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # personal credentials are added here: do not check in.
 tests/integration/cloud-config-gcp.ini
+ansible.cfg
 # running ansible integration tests adds files here.
 tests/integration/inventory
 tests/output/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Google Cloud Platform Ansible Collection
 This collection provides a series of Ansible modules and plugins for interacting with the [Google Cloud Platform](https://cloud.google.com)
 
-This collection works with Ansible 2.9+
+This collection works with Ansible 2.14+
 
 # Installation
 ```bash


### PR DESCRIPTION
Missed this one when doing the v1.3.0 upgrade work - saw it *after* I released it to [Ansible Galaxy](https://galaxy.ansible.com/ui/repo/published/google/cloud/) :-(

Also added `ansible.cfg` to `.gitignore` while I'm here.