### PR TITLE
add preffix option to hostname creation

### DIFF
--- a/plugins/inventory/gcp_compute.py
+++ b/plugins/inventory/gcp_compute.py
@@ -112,6 +112,13 @@ DOCUMENTATION = """
             - Unless this option is enabled, the C(image) host variable will be C(null)
           type: bool
           default: False
+        hostname_prefix:
+            description: Ooptional preffix to add beofre a hostname is created, it could be static value or dynamic value
+            required: False
+            type: string
+            default: ''
+
+          
 """
 
 EXAMPLES = """
@@ -168,12 +175,13 @@ class GcpMockModule(object):
 
 class GcpInstance(object):
     def __init__(
-        self, json, hostname_ordering, project_disks, should_format=True, name_suffix=""
+        self, json, hostname_ordering, project_disks, should_format=True, name_suffix="", hostname_prefix=""
     ):
         self.hostname_ordering = hostname_ordering
         self.project_disks = project_disks
         self.name_suffix = name_suffix
         self.json = json
+        self.hostname_prefix = hostname_prefix
         if should_format:
             self.convert()
 
@@ -244,7 +252,7 @@ class GcpInstance(object):
             elif order == "private_ip":
                 name = self._get_privateip()
             elif order == "name":
-                name = self.json["name"] + self.name_suffix
+                name = self.hostname_prefix + self.json["name"]  + self.name_suffix
             else:
                 raise AnsibleParserError("%s is not a valid hostname precedent" % order)
 
@@ -425,6 +433,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         :param config_data: configuration data
         :param format_items: format items or not
         """
+        hostname_prefix = self.get_option("hostname_prefix")
         if not items:
             return
 
@@ -436,7 +445,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         for host_json in items:
             host = GcpInstance(
-                host_json, hostname_ordering, project_disks, format_items, name_suffix
+                host_json, hostname_ordering, project_disks, format_items, name_suffix, hostname_prefix
             )
             self._populate_host(host)
 


### PR DESCRIPTION


##### SUMMARY
add the option for the user to add a hostname_prefix in case the user wants to add a prefix to the hostname, focused on AAP or AWX that hostnames are by default the name shown in the UI


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Add new parameter and function hostname_prefix handling

##### ADDITIONAL INFORMATION
Now when in AWX or AAP or any Ansible UI that shows the hosts in inventory, in gcp it is not possible to add a prefix to the host name (which is the hostname variable in dynamic inventories). With this change you can add a prefix to the host name if for example you have two projects in gcp and you have two machines with the same name, this way you can put for example project_1 + host name and in another project_2 + host name.


<!--- Paste verbatim command output below, e.g. before and after your change -->
**Before the change:**
```
plugin: google.cloud.gcp_compute
auth_kind: serviceaccount
service_account_file: your path to creds json

projects:
  - 12345
hostnames:
  - name
```
Result of the hostname was :
```

        "hosts": [
            "machine-1",
            "machine-2"
        ]
    }
```


**After the change:** 
```
plugin: google.cloud.gcp_compute
auth_kind: serviceaccount
service_account_file: your path to creds json

projects:
  - 12345
hostnames:
  - name
hostname_prefix: 'i_am_a_test'

```

        "hosts": [
            "i_am_a_testmachine-1",
            "i_am_a_testmachine-2"
        ]
    }
