### PR TITLE
Service account impersonation

### DIFF
--- a/plugins/doc_fragments/gcp.py
+++ b/plugins/doc_fragments/gcp.py
@@ -21,7 +21,7 @@ options:
             - The type of credential used.
         type: str
         required: true
-        choices: [ application, machineaccount, serviceaccount ]
+        choices: [ application, machineaccount, serviceaccount, impersonation ]
     service_account_contents:
         description:
             - The contents of a Service Account JSON file, either in a dictionary or as a JSON string that represents it.

--- a/plugins/inventory/gcp_compute.py
+++ b/plugins/inventory/gcp_compute.py
@@ -57,7 +57,7 @@ DOCUMENTATION = """
             description:
                 - The type of credential used.
             required: True
-            choices: ['application', 'serviceaccount', 'machineaccount', 'accesstoken']
+            choices: ['application', 'serviceaccount', 'machineaccount', 'accesstoken', 'impersonation']
             env:
                 - name: GCP_AUTH_KIND
         scopes:
@@ -84,6 +84,7 @@ DOCUMENTATION = """
             description:
                 - An optional service account email address if machineaccount is selected
                   and the user does not wish to use the default email.
+                - Required service account to impersonate if impersonation is selected.
             env:
                 - name: GCP_SERVICE_ACCOUNT_EMAIL
         access_token:

--- a/plugins/modules/gcp_appengine_firewall_rule.py
+++ b/plugins/modules/gcp_appengine_firewall_rule.py
@@ -88,6 +88,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -101,6 +102,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_appengine_firewall_rule_info.py
+++ b/plugins/modules/gcp_appengine_firewall_rule_info.py
@@ -53,6 +53,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -66,6 +67,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_bigquery_dataset.py
+++ b/plugins/modules/gcp_bigquery_dataset.py
@@ -225,6 +225,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -238,6 +239,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_bigquery_dataset_info.py
+++ b/plugins/modules/gcp_bigquery_dataset_info.py
@@ -53,6 +53,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -66,6 +67,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_bigquery_table.py
+++ b/plugins/modules/gcp_bigquery_table.py
@@ -476,6 +476,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -489,6 +490,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_bigquery_table_info.py
+++ b/plugins/modules/gcp_bigquery_table_info.py
@@ -71,6 +71,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_bigtable_instance.py
+++ b/plugins/modules/gcp_bigtable_instance.py
@@ -118,6 +118,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -131,6 +132,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_bigtable_instance_info.py
+++ b/plugins/modules/gcp_bigtable_instance_info.py
@@ -53,6 +53,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -66,6 +67,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_cloudbuild_trigger.py
+++ b/plugins/modules/gcp_cloudbuild_trigger.py
@@ -728,6 +728,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -741,6 +742,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_cloudbuild_trigger_info.py
+++ b/plugins/modules/gcp_cloudbuild_trigger_info.py
@@ -53,6 +53,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -66,6 +67,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_cloudfunctions_cloud_function.py
+++ b/plugins/modules/gcp_cloudfunctions_cloud_function.py
@@ -175,6 +175,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -188,6 +189,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_cloudfunctions_cloud_function_info.py
+++ b/plugins/modules/gcp_cloudfunctions_cloud_function_info.py
@@ -58,6 +58,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -71,6 +72,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_cloudscheduler_job.py
+++ b/plugins/modules/gcp_cloudscheduler_job.py
@@ -311,6 +311,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -324,6 +325,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_cloudscheduler_job_info.py
+++ b/plugins/modules/gcp_cloudscheduler_job_info.py
@@ -58,6 +58,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -71,6 +72,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_cloudtasks_queue.py
+++ b/plugins/modules/gcp_cloudtasks_queue.py
@@ -189,6 +189,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -202,6 +203,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_cloudtasks_queue_info.py
+++ b/plugins/modules/gcp_cloudtasks_queue_info.py
@@ -58,6 +58,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -71,6 +72,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_address.py
+++ b/plugins/modules/gcp_compute_address.py
@@ -154,6 +154,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -167,6 +168,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_address_info.py
+++ b/plugins/modules/gcp_compute_address_info.py
@@ -66,6 +66,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -79,6 +80,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_autoscaler.py
+++ b/plugins/modules/gcp_compute_autoscaler.py
@@ -261,6 +261,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -274,6 +275,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_autoscaler_info.py
+++ b/plugins/modules/gcp_compute_autoscaler_info.py
@@ -65,6 +65,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -78,6 +79,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_backend_bucket.py
+++ b/plugins/modules/gcp_compute_backend_bucket.py
@@ -175,6 +175,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -188,6 +189,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_backend_bucket_info.py
+++ b/plugins/modules/gcp_compute_backend_bucket_info.py
@@ -60,6 +60,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -73,6 +74,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_backend_service.py
+++ b/plugins/modules/gcp_compute_backend_service.py
@@ -703,6 +703,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -716,6 +717,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_backend_service_info.py
+++ b/plugins/modules/gcp_compute_backend_service_info.py
@@ -60,6 +60,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -73,6 +74,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_disk.py
+++ b/plugins/modules/gcp_compute_disk.py
@@ -239,6 +239,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -252,6 +253,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_disk_info.py
+++ b/plugins/modules/gcp_compute_disk_info.py
@@ -65,6 +65,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -78,6 +79,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_external_vpn_gateway.py
+++ b/plugins/modules/gcp_compute_external_vpn_gateway.py
@@ -105,6 +105,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -118,6 +119,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_external_vpn_gateway_info.py
+++ b/plugins/modules/gcp_compute_external_vpn_gateway_info.py
@@ -60,6 +60,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -73,6 +74,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_firewall.py
+++ b/plugins/modules/gcp_compute_firewall.py
@@ -264,6 +264,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -277,6 +278,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_firewall_info.py
+++ b/plugins/modules/gcp_compute_firewall_info.py
@@ -60,6 +60,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -73,6 +74,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_forwarding_rule.py
+++ b/plugins/modules/gcp_compute_forwarding_rule.py
@@ -238,6 +238,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -251,6 +252,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_forwarding_rule_info.py
+++ b/plugins/modules/gcp_compute_forwarding_rule_info.py
@@ -66,6 +66,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -79,6 +80,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_global_address.py
+++ b/plugins/modules/gcp_compute_global_address.py
@@ -125,6 +125,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -138,6 +139,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_global_address_info.py
+++ b/plugins/modules/gcp_compute_global_address_info.py
@@ -60,6 +60,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -73,6 +74,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_global_forwarding_rule.py
+++ b/plugins/modules/gcp_compute_global_forwarding_rule.py
@@ -218,6 +218,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -231,6 +232,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_global_forwarding_rule_info.py
+++ b/plugins/modules/gcp_compute_global_forwarding_rule_info.py
@@ -60,6 +60,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -73,6 +74,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_health_check.py
+++ b/plugins/modules/gcp_compute_health_check.py
@@ -473,6 +473,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -486,6 +487,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_health_check_info.py
+++ b/plugins/modules/gcp_compute_health_check_info.py
@@ -60,6 +60,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -73,6 +74,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_http_health_check.py
+++ b/plugins/modules/gcp_compute_http_health_check.py
@@ -126,6 +126,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -139,6 +140,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_http_health_check_info.py
+++ b/plugins/modules/gcp_compute_http_health_check_info.py
@@ -60,6 +60,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -73,6 +74,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_https_health_check.py
+++ b/plugins/modules/gcp_compute_https_health_check.py
@@ -123,6 +123,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -136,6 +137,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_https_health_check_info.py
+++ b/plugins/modules/gcp_compute_https_health_check_info.py
@@ -60,6 +60,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -73,6 +74,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_image.py
+++ b/plugins/modules/gcp_compute_image.py
@@ -230,6 +230,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -243,6 +244,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_image_info.py
+++ b/plugins/modules/gcp_compute_image_info.py
@@ -60,6 +60,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -73,6 +74,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_instance.py
+++ b/plugins/modules/gcp_compute_instance.py
@@ -523,6 +523,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -536,6 +537,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_instance_group.py
+++ b/plugins/modules/gcp_compute_instance_group.py
@@ -139,6 +139,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -152,6 +153,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_instance_group_info.py
+++ b/plugins/modules/gcp_compute_instance_group_info.py
@@ -65,6 +65,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -78,6 +79,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_instance_group_manager.py
+++ b/plugins/modules/gcp_compute_instance_group_manager.py
@@ -137,6 +137,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -150,6 +151,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_instance_group_manager_info.py
+++ b/plugins/modules/gcp_compute_instance_group_manager_info.py
@@ -65,6 +65,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -78,6 +79,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_instance_info.py
+++ b/plugins/modules/gcp_compute_instance_info.py
@@ -69,6 +69,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -82,6 +83,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_instance_template.py
+++ b/plugins/modules/gcp_compute_instance_template.py
@@ -486,6 +486,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -499,6 +500,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_instance_template_info.py
+++ b/plugins/modules/gcp_compute_instance_template_info.py
@@ -60,6 +60,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -73,6 +74,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_interconnect_attachment.py
+++ b/plugins/modules/gcp_compute_interconnect_attachment.py
@@ -195,6 +195,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -208,6 +209,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_interconnect_attachment_info.py
+++ b/plugins/modules/gcp_compute_interconnect_attachment_info.py
@@ -65,6 +65,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -78,6 +79,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_network.py
+++ b/plugins/modules/gcp_compute_network.py
@@ -109,6 +109,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -122,6 +123,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_network_endpoint_group.py
+++ b/plugins/modules/gcp_compute_network_endpoint_group.py
@@ -125,6 +125,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -138,6 +139,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_network_endpoint_group_info.py
+++ b/plugins/modules/gcp_compute_network_endpoint_group_info.py
@@ -65,6 +65,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -78,6 +79,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_network_info.py
+++ b/plugins/modules/gcp_compute_network_info.py
@@ -60,6 +60,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -73,6 +74,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_node_group.py
+++ b/plugins/modules/gcp_compute_node_group.py
@@ -142,6 +142,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -155,6 +156,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_node_group_info.py
+++ b/plugins/modules/gcp_compute_node_group_info.py
@@ -65,6 +65,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -78,6 +79,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_node_template.py
+++ b/plugins/modules/gcp_compute_node_template.py
@@ -136,6 +136,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -149,6 +150,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_node_template_info.py
+++ b/plugins/modules/gcp_compute_node_template_info.py
@@ -65,6 +65,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -78,6 +79,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_region_autoscaler.py
+++ b/plugins/modules/gcp_compute_region_autoscaler.py
@@ -238,6 +238,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -251,6 +252,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_region_autoscaler_info.py
+++ b/plugins/modules/gcp_compute_region_autoscaler_info.py
@@ -65,6 +65,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -78,6 +79,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_region_backend_service.py
+++ b/plugins/modules/gcp_compute_region_backend_service.py
@@ -719,6 +719,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -732,6 +733,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_region_backend_service_info.py
+++ b/plugins/modules/gcp_compute_region_backend_service_info.py
@@ -65,6 +65,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -78,6 +79,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_region_disk.py
+++ b/plugins/modules/gcp_compute_region_disk.py
@@ -177,6 +177,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -190,6 +191,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_region_disk_info.py
+++ b/plugins/modules/gcp_compute_region_disk_info.py
@@ -65,6 +65,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -78,6 +79,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_region_health_check.py
+++ b/plugins/modules/gcp_compute_region_health_check.py
@@ -473,6 +473,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -486,6 +487,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_region_health_check_info.py
+++ b/plugins/modules/gcp_compute_region_health_check_info.py
@@ -65,6 +65,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -78,6 +79,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_region_instance_group_manager.py
+++ b/plugins/modules/gcp_compute_region_instance_group_manager.py
@@ -155,6 +155,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -168,6 +169,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_region_instance_group_manager_info.py
+++ b/plugins/modules/gcp_compute_region_instance_group_manager_info.py
@@ -65,6 +65,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -78,6 +79,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_region_target_http_proxy.py
+++ b/plugins/modules/gcp_compute_region_target_http_proxy.py
@@ -93,6 +93,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -106,6 +107,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_region_target_http_proxy_info.py
+++ b/plugins/modules/gcp_compute_region_target_http_proxy_info.py
@@ -65,6 +65,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -78,6 +79,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_region_target_https_proxy.py
+++ b/plugins/modules/gcp_compute_region_target_https_proxy.py
@@ -101,6 +101,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -114,6 +115,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_region_target_https_proxy_info.py
+++ b/plugins/modules/gcp_compute_region_target_https_proxy_info.py
@@ -65,6 +65,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -78,6 +79,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_region_url_map.py
+++ b/plugins/modules/gcp_compute_region_url_map.py
@@ -1603,6 +1603,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -1616,6 +1617,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_region_url_map_info.py
+++ b/plugins/modules/gcp_compute_region_url_map_info.py
@@ -65,6 +65,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -78,6 +79,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_reservation.py
+++ b/plugins/modules/gcp_compute_reservation.py
@@ -163,6 +163,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -176,6 +177,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_reservation_info.py
+++ b/plugins/modules/gcp_compute_reservation_info.py
@@ -65,6 +65,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -78,6 +79,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_resource_policy.py
+++ b/plugins/modules/gcp_compute_resource_policy.py
@@ -275,6 +275,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -288,6 +289,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_resource_policy_info.py
+++ b/plugins/modules/gcp_compute_resource_policy_info.py
@@ -65,6 +65,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -78,6 +79,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_route.py
+++ b/plugins/modules/gcp_compute_route.py
@@ -175,6 +175,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -188,6 +189,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_route_info.py
+++ b/plugins/modules/gcp_compute_route_info.py
@@ -60,6 +60,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -73,6 +74,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_router.py
+++ b/plugins/modules/gcp_compute_router.py
@@ -142,6 +142,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -155,6 +156,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_router_info.py
+++ b/plugins/modules/gcp_compute_router_info.py
@@ -65,6 +65,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -78,6 +79,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_snapshot.py
+++ b/plugins/modules/gcp_compute_snapshot.py
@@ -158,6 +158,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -171,6 +172,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_snapshot_info.py
+++ b/plugins/modules/gcp_compute_snapshot_info.py
@@ -60,6 +60,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -73,6 +74,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_ssl_certificate.py
+++ b/plugins/modules/gcp_compute_ssl_certificate.py
@@ -90,6 +90,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -103,6 +104,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_ssl_certificate_info.py
+++ b/plugins/modules/gcp_compute_ssl_certificate_info.py
@@ -60,6 +60,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -73,6 +74,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_ssl_policy.py
+++ b/plugins/modules/gcp_compute_ssl_policy.py
@@ -100,6 +100,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -113,6 +114,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_ssl_policy_info.py
+++ b/plugins/modules/gcp_compute_ssl_policy_info.py
@@ -60,6 +60,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -73,6 +74,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_subnetwork.py
+++ b/plugins/modules/gcp_compute_subnetwork.py
@@ -152,6 +152,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -165,6 +166,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_subnetwork_info.py
+++ b/plugins/modules/gcp_compute_subnetwork_info.py
@@ -65,6 +65,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -78,6 +79,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_target_http_proxy.py
+++ b/plugins/modules/gcp_compute_target_http_proxy.py
@@ -94,6 +94,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -107,6 +108,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_target_http_proxy_info.py
+++ b/plugins/modules/gcp_compute_target_http_proxy_info.py
@@ -60,6 +60,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -73,6 +74,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_target_https_proxy.py
+++ b/plugins/modules/gcp_compute_target_https_proxy.py
@@ -122,6 +122,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -135,6 +136,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_target_https_proxy_info.py
+++ b/plugins/modules/gcp_compute_target_https_proxy_info.py
@@ -60,6 +60,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -73,6 +74,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_target_instance.py
+++ b/plugins/modules/gcp_compute_target_instance.py
@@ -105,6 +105,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -118,6 +119,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_target_instance_info.py
+++ b/plugins/modules/gcp_compute_target_instance_info.py
@@ -65,6 +65,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -78,6 +79,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_target_pool.py
+++ b/plugins/modules/gcp_compute_target_pool.py
@@ -147,6 +147,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -160,6 +161,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_target_pool_info.py
+++ b/plugins/modules/gcp_compute_target_pool_info.py
@@ -65,6 +65,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -78,6 +79,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_target_ssl_proxy.py
+++ b/plugins/modules/gcp_compute_target_ssl_proxy.py
@@ -112,6 +112,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -125,6 +126,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_target_ssl_proxy_info.py
+++ b/plugins/modules/gcp_compute_target_ssl_proxy_info.py
@@ -60,6 +60,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -73,6 +74,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_target_tcp_proxy.py
+++ b/plugins/modules/gcp_compute_target_tcp_proxy.py
@@ -99,6 +99,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -112,6 +113,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_target_tcp_proxy_info.py
+++ b/plugins/modules/gcp_compute_target_tcp_proxy_info.py
@@ -60,6 +60,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -73,6 +74,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_target_vpn_gateway.py
+++ b/plugins/modules/gcp_compute_target_vpn_gateway.py
@@ -92,6 +92,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -105,6 +106,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_target_vpn_gateway_info.py
+++ b/plugins/modules/gcp_compute_target_vpn_gateway_info.py
@@ -65,6 +65,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -78,6 +79,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_url_map.py
+++ b/plugins/modules/gcp_compute_url_map.py
@@ -2548,6 +2548,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -2561,6 +2562,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_url_map_info.py
+++ b/plugins/modules/gcp_compute_url_map_info.py
@@ -60,6 +60,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -73,6 +74,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_vpn_tunnel.py
+++ b/plugins/modules/gcp_compute_vpn_tunnel.py
@@ -179,6 +179,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -192,6 +193,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_compute_vpn_tunnel_info.py
+++ b/plugins/modules/gcp_compute_vpn_tunnel_info.py
@@ -65,6 +65,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -78,6 +79,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_container_cluster.py
+++ b/plugins/modules/gcp_container_cluster.py
@@ -692,6 +692,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -705,6 +706,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_container_cluster_info.py
+++ b/plugins/modules/gcp_container_cluster_info.py
@@ -61,6 +61,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -74,6 +75,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_container_node_pool.py
+++ b/plugins/modules/gcp_container_node_pool.py
@@ -359,6 +359,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -372,6 +373,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_container_node_pool_info.py
+++ b/plugins/modules/gcp_container_node_pool_info.py
@@ -71,6 +71,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -84,6 +85,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_dns_managed_zone.py
+++ b/plugins/modules/gcp_dns_managed_zone.py
@@ -235,6 +235,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -248,6 +249,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_dns_managed_zone_info.py
+++ b/plugins/modules/gcp_dns_managed_zone_info.py
@@ -58,6 +58,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -71,6 +72,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_dns_resource_record_set.py
+++ b/plugins/modules/gcp_dns_resource_record_set.py
@@ -95,6 +95,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -108,6 +109,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_dns_resource_record_set_info.py
+++ b/plugins/modules/gcp_dns_resource_record_set_info.py
@@ -60,6 +60,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -73,6 +74,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_filestore_instance.py
+++ b/plugins/modules/gcp_filestore_instance.py
@@ -132,6 +132,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -145,6 +146,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_filestore_instance_info.py
+++ b/plugins/modules/gcp_filestore_instance_info.py
@@ -58,6 +58,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -71,6 +72,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_iam_role.py
+++ b/plugins/modules/gcp_iam_role.py
@@ -94,6 +94,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -107,6 +108,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_iam_role_info.py
+++ b/plugins/modules/gcp_iam_role_info.py
@@ -53,6 +53,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -66,6 +67,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_iam_service_account.py
+++ b/plugins/modules/gcp_iam_service_account.py
@@ -71,6 +71,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -84,6 +85,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_iam_service_account_info.py
+++ b/plugins/modules/gcp_iam_service_account_info.py
@@ -53,6 +53,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -66,6 +67,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_iam_service_account_key.py
+++ b/plugins/modules/gcp_iam_service_account_key.py
@@ -91,6 +91,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -104,6 +105,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_kms_crypto_key.py
+++ b/plugins/modules/gcp_kms_crypto_key.py
@@ -119,6 +119,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -132,6 +133,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_kms_crypto_key_info.py
+++ b/plugins/modules/gcp_kms_crypto_key_info.py
@@ -59,6 +59,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -72,6 +73,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_kms_key_ring.py
+++ b/plugins/modules/gcp_kms_key_ring.py
@@ -73,6 +73,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -86,6 +87,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_kms_key_ring_info.py
+++ b/plugins/modules/gcp_kms_key_ring_info.py
@@ -60,6 +60,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -73,6 +74,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_logging_metric.py
+++ b/plugins/modules/gcp_logging_metric.py
@@ -240,6 +240,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -253,6 +254,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_logging_metric_info.py
+++ b/plugins/modules/gcp_logging_metric_info.py
@@ -53,6 +53,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -66,6 +67,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_mlengine_model.py
+++ b/plugins/modules/gcp_mlengine_model.py
@@ -108,6 +108,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -121,6 +122,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_mlengine_model_info.py
+++ b/plugins/modules/gcp_mlengine_model_info.py
@@ -53,6 +53,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -66,6 +67,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_mlengine_version.py
+++ b/plugins/modules/gcp_mlengine_version.py
@@ -171,6 +171,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -184,6 +185,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_mlengine_version_info.py
+++ b/plugins/modules/gcp_mlengine_version_info.py
@@ -63,6 +63,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -76,6 +77,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_pubsub_subscription.py
+++ b/plugins/modules/gcp_pubsub_subscription.py
@@ -274,6 +274,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -287,6 +288,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_pubsub_subscription_info.py
+++ b/plugins/modules/gcp_pubsub_subscription_info.py
@@ -53,6 +53,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -66,6 +67,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_pubsub_topic.py
+++ b/plugins/modules/gcp_pubsub_topic.py
@@ -118,6 +118,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -131,6 +132,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_pubsub_topic_info.py
+++ b/plugins/modules/gcp_pubsub_topic_info.py
@@ -53,6 +53,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -66,6 +67,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_redis_instance.py
+++ b/plugins/modules/gcp_redis_instance.py
@@ -163,6 +163,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -176,6 +177,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_redis_instance_info.py
+++ b/plugins/modules/gcp_redis_instance_info.py
@@ -58,6 +58,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -71,6 +72,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_resourcemanager_project.py
+++ b/plugins/modules/gcp_resourcemanager_project.py
@@ -104,6 +104,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -117,6 +118,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_resourcemanager_project_info.py
+++ b/plugins/modules/gcp_resourcemanager_project_info.py
@@ -53,6 +53,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -66,6 +67,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_runtimeconfig_config.py
+++ b/plugins/modules/gcp_runtimeconfig_config.py
@@ -72,6 +72,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -85,6 +86,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_runtimeconfig_config_info.py
+++ b/plugins/modules/gcp_runtimeconfig_config_info.py
@@ -53,6 +53,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -66,6 +67,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_runtimeconfig_variable.py
+++ b/plugins/modules/gcp_runtimeconfig_variable.py
@@ -81,6 +81,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -94,6 +95,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_runtimeconfig_variable_info.py
+++ b/plugins/modules/gcp_runtimeconfig_variable_info.py
@@ -58,6 +58,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -71,6 +72,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_serviceusage_service.py
+++ b/plugins/modules/gcp_serviceusage_service.py
@@ -72,6 +72,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -85,6 +86,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_serviceusage_service_info.py
+++ b/plugins/modules/gcp_serviceusage_service_info.py
@@ -53,6 +53,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -66,6 +67,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_sourcerepo_repository.py
+++ b/plugins/modules/gcp_sourcerepo_repository.py
@@ -68,6 +68,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -81,6 +82,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_sourcerepo_repository_info.py
+++ b/plugins/modules/gcp_sourcerepo_repository_info.py
@@ -53,6 +53,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -66,6 +67,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_spanner_database.py
+++ b/plugins/modules/gcp_spanner_database.py
@@ -98,6 +98,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -111,6 +112,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_spanner_database_info.py
+++ b/plugins/modules/gcp_spanner_database_info.py
@@ -63,6 +63,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -76,6 +77,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_spanner_instance.py
+++ b/plugins/modules/gcp_spanner_instance.py
@@ -101,6 +101,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -114,6 +115,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_spanner_instance_info.py
+++ b/plugins/modules/gcp_spanner_instance_info.py
@@ -53,6 +53,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -66,6 +67,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_sql_database.py
+++ b/plugins/modules/gcp_sql_database.py
@@ -88,6 +88,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -101,6 +102,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_sql_database_info.py
+++ b/plugins/modules/gcp_sql_database_info.py
@@ -58,6 +58,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -71,6 +72,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_sql_instance.py
+++ b/plugins/modules/gcp_sql_instance.py
@@ -371,6 +371,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -384,6 +385,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_sql_instance_info.py
+++ b/plugins/modules/gcp_sql_instance_info.py
@@ -53,6 +53,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -66,6 +67,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_sql_ssl_cert.py
+++ b/plugins/modules/gcp_sql_ssl_cert.py
@@ -107,6 +107,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -120,6 +121,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_sql_user.py
+++ b/plugins/modules/gcp_sql_user.py
@@ -88,6 +88,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -101,6 +102,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_sql_user_info.py
+++ b/plugins/modules/gcp_sql_user_info.py
@@ -63,6 +63,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -76,6 +77,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_storage_bucket.py
+++ b/plugins/modules/gcp_storage_bucket.py
@@ -415,6 +415,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -428,6 +429,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_storage_bucket_access_control.py
+++ b/plugins/modules/gcp_storage_bucket_access_control.py
@@ -96,6 +96,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -109,6 +110,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_storage_default_object_acl.py
+++ b/plugins/modules/gcp_storage_default_object_acl.py
@@ -90,6 +90,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -103,6 +104,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_storage_object.py
+++ b/plugins/modules/gcp_storage_object.py
@@ -70,6 +70,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -83,6 +84,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_tpu_node.py
+++ b/plugins/modules/gcp_tpu_node.py
@@ -131,6 +131,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -144,6 +145,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:

--- a/plugins/modules/gcp_tpu_node_info.py
+++ b/plugins/modules/gcp_tpu_node_info.py
@@ -58,6 +58,7 @@ options:
     - machineaccount
     - serviceaccount
     - accesstoken
+    - impersonation
   service_account_contents:
     description:
     - The contents of a Service Account JSON file, either in a dictionary or as a
@@ -71,6 +72,7 @@ options:
     description:
     - An optional service account email address if machineaccount is selected and
       the user does not wish to use the default email.
+    - Required service account to impersonate if impersonation is selected.
     type: str
   access_token:
     description:


### PR DESCRIPTION
##### SUMMARY
Add support for [service account impersonation](https://cloud.google.com/docs/authentication/use-service-account-impersonation) as a credential option.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
gcp-util

##### ADDITIONAL INFORMATION
Added the option to gcp-util and updated docs that reference credential methods.
