### PR TITLE
fix: support more than 10 secrets versions on gcp_secret_manager

### DIFF
--- a/plugins/lookup/gcp_secret_manager.py
+++ b/plugins/lookup/gcp_secret_manager.py
@@ -208,7 +208,10 @@ class LookupModule(LookupBase):
             self.raise_error(module, f"unable to list versions of secret {response.status_code}")
         version_list = response.json()
         if "versions" in version_list:
-            return sorted(version_list['versions'], key=lambda d: d['name'])[-1]['name'].split('/')[-1]
+            versions_numbers = []
+            for version in version_list['versions']:
+                versions_numbers.append(version['name'].split('/')[-1])
+            return sorted(versions_numbers, key=int)[-1]
         else:
             self.raise_error(module, f"Unable to list secret versions via {response.request.url}: {response.json()}")
 

--- a/plugins/modules/gcp_secret_manager.py
+++ b/plugins/modules/gcp_secret_manager.py
@@ -261,7 +261,10 @@ def fetch_resource(module, allow_not_found=True):
             return None
 
         if "versions" in version_list:
-            latest_version = sorted(version_list['versions'], key=lambda d: d['name'])[-1]['name'].split('/')[-1]
+            versions_numbers = []
+            for version in version_list['versions']:
+                versions_numbers.append(version['name'].split('/')[-1])
+            latest_version = sorted(versions_numbers, key=int)[-1]
             module.params['calc_version'] = latest_version
         else:
             # if this occurs, there are no available secret versions


### PR DESCRIPTION
##### SUMMARY

The `gcp_secret_manager` module and `gcp_secret_manager` lookup do not support more than 10 secrets versions when you try to get the latest version. The problem is that it sorts the paths before getting the version, so somepath/12 is smaller than somepath/9, so it always returns 9 as the latest version.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

gcp_secret_manager

##### ADDITIONAL INFORMATION

The following steps expose the issue:
* Create a secret
* Add 10 or more versions
* get the latest versions with the module or the lookup

The following script create a test case with both issues.

```shell
#!/usr/bin/env bash

gcloud secrets create test-10-versions --replication-policy="automatic"
for i in {1..10}
do
    echo "Secret version $i" > ./file.txt
    gcloud secrets versions add test-10-versions --data-file="${PWD}/file.txt"
done
rm ./file.txt

cat > playbook.yml <<EOF
---
- name: Custom Destroy
  hosts: localhost
  connection: local
  gather_facts: true
  tasks:
    - name: Get Secret version 10
      debug:
        msg: |
          version 10: {{ lookup('google.cloud.gcp_secret_manager', key='test-10-versions', version=10) }}
    - name: Get Secret version 9
      debug:
        msg: |
          version 9: {{ lookup('google.cloud.gcp_secret_manager', key='test-10-versions', version=9) }}
    - name: Get Secret version latest
      debug:
        msg: |
          version latest: {{ lookup('google.cloud.gcp_secret_manager', key='test-10-versions') }}
EOF

export GCP_PROJECT=$(gcloud config get-value project)
export GCP_AUTH_KIND=accesstoken
export GCP_ACCESS_TOKEN=$(gcloud auth print-access-token)

ansible-playbook playbook.yml 


cat > playbook2.yml <<EOF
---
- name: Custom Destroy
  hosts: localhost
  connection: local
  gather_facts: true
  tasks:
    - name: Get Secret version latest
      google.cloud.gcp_secret_manager:
        name: test-10-versions
        state: present
        return_value: true
EOF

ansible-playbook -vv playbook2.yml 
```
