### PR TITLE
Bump min Ansible version to 2.16

### DIFF
--- a/.github/workflows/ansible-integration-tests.yml
+++ b/.github/workflows/ansible-integration-tests.yml
@@ -21,9 +21,12 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
+        # Our current version strategy is to support both supported versions of ansible-core
+        # and test against the minimum version of Python supported by both. If/when we change
+        # the integration tests to support parallelism we can revisit.
         ansible_version:
-          - stable-2.14
-          - stable-2.15
+          - stable-2.16
+          - stable-2.17
     steps:
       - name: check out code
         uses: actions/checkout@v4
@@ -32,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'  # this is the minimum version required for Ansible 2.15
+          python-version: '3.10'  # this is the minimum version required for Ansible 2.16
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Install ansible-base (${{ matrix.ansible_version }})
@@ -67,4 +70,4 @@ jobs:
       # run tests
       - name: Run integration tests
         # Add the -vvv flag to print out more output
-        run: ansible-test integration -v --color --python 3.9 --venv-system-site-packages
+        run: ansible-test integration -v --color --python 3.10 --venv-system-site-packages

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -1,8 +1,6 @@
 ---
 name: Run tests for the cloud.google collection
 on: [pull_request]
-env:
-  PYTHON_VERSION: "3.9" # minimum version for Ansible 2.15
 jobs:
   sanity-and-lint:
     runs-on: ubuntu-latest
@@ -11,9 +9,16 @@ jobs:
         working-directory: ansible_collections/google/cloud
     strategy:
       matrix:
+        # Our version strategy is to test against the current and previous version
+        # of ansible-core and each major version of Python supported by both.
+        # https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
         ansible_version:
-          - stable-2.14
-          - stable-2.15
+          - stable-2.16
+          - stable-2.17
+        python_version:
+          - '3.10'
+          - '3.11'
+          - '3.12'
     steps:
       - name: check out code
         uses: actions/checkout@v4
@@ -23,25 +28,14 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      # Automation-hub requires python2.7 sanity tests
-      - name: setup python2.7
-        run: |
-          sudo apt-add-repository universe
-          sudo apt update
-          sudo apt install python2.7
-          curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
-          sudo /usr/bin/python2.7 get-pip.py
-          pip2 install virtualenv
+          python-version: ${{ matrix.python_version }}
       - name: Install ansible-base (${{ matrix.ansible_version }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible_version }}.tar.gz --disable-pip-version-check
       - name: Run ansible-test sanity
         # validate-modules cannot be turned on until #498 is resolved.
         run: ansible-test sanity -v --color --skip validate-modules
-      - name: Install ansible-lint
-        run: pip install ansible-lint==6.22.0
       - name: Run ansible-lint
-        run: ansible-lint
+        uses: ansible/ansible-lint@v24.7.0
   unit:
     runs-on: ubuntu-latest
     defaults:
@@ -50,8 +44,12 @@ jobs:
     strategy:
       matrix:
         ansible_version:
-          - stable-2.14
-          - stable-2.15
+          - stable-2.16
+          - stable-2.17
+        python_version:
+          - '3.10'
+          - '3.11'
+          - '3.12'
     steps:
       - name: check out code
         uses: actions/checkout@v4
@@ -60,7 +58,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ matrix.python_version }}
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Install test dependencies
@@ -68,4 +66,4 @@ jobs:
       - name: Install ansible-base (${{ matrix.ansible_version }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible_version }}.tar.gz --disable-pip-version-check
       - name: Run unit tests
-        run: ansible-test units -v --color --python "$PYTHON_VERSION"
+        run: ansible-test units -v --color --python "${{ matrix.python_version }}"

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -34,8 +34,10 @@ jobs:
       - name: Run ansible-test sanity
         # validate-modules cannot be turned on until #498 is resolved.
         run: ansible-test sanity -v --color --skip validate-modules
+      - name: Install ansible-lint
+        run: pip install ansible-lint==24.7.0
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@v24.7.0
+        run: ansible-lint
   unit:
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/gcloud.yml
+++ b/.github/workflows/gcloud.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/gcloud.yml
+++ b/.github/workflows/gcloud.yml
@@ -31,10 +31,10 @@ jobs:
         with:
           path: ansible_collections/google/cloud
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.10
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/gcsfuse.yml
+++ b/.github/workflows/gcsfuse.yml
@@ -26,10 +26,10 @@ jobs:
         with:
           path: ansible_collections/google/cloud
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.10
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/gcsfuse.yml
+++ b/.github/workflows/gcsfuse.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
       - name: Install dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Google Cloud Platform Ansible Collection
 This collection provides a series of Ansible modules and plugins for interacting with the [Google Cloud Platform](https://cloud.google.com)
 
-This collection works with Ansible 2.14+
+This collection works with Ansible 2.16+
 
 # Installation
 ```bash

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: ">=2.14.0"
+requires_ansible: ">=2.16.0"
 
 action_groups:
   gcp:


### PR DESCRIPTION
Also:

- Modify GitHub workflows to run unit tests and lint using all supported Python versions (3.10, 3.11, and 3.12 as of now)
- Drop testing with Python 2.7 as it's no longer supported or required
- Run integration tests with Python 3.10
- ~~Use the [run-ansible-lint](https://github.com/marketplace/actions/run-ansible-lint) GitHub action rather than installing directly~~ The action [doesn't work when running outside of the root workspace directory](https://github.com/ansible/ansible-lint/issues/3938).

This is one of multiple PRs to perform the upgrade; it fixes some issues but adds new issues (new linter errors due to a newer version of `ansible-lint` and broken role tests, to name a couple).