### PR TITLE
Make code coverage messages informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
I switched our GitHub actions to use [ansible-test-gh-action](https://github.com/ansible-community/ansible-test-gh-action) which had the side effect of enabling code coverage with a default config that blocks any PR that reduces coverage, however slightly. This will (according to the docs) make coverage checks informational rather than blocking.