### PR TITLE
Add `discard_local_ssd` flag to compute instance

### DIFF
--- a/plugins/modules/gcp_compute_instance.py
+++ b/plugins/modules/gcp_compute_instance.py
@@ -61,6 +61,12 @@ options:
     - Whether the resource should be protected against deletion.
     required: false
     type: bool
+  discard_local_ssd:
+    description:
+    - If true, the contents of any attached Local SSD disks will be discarded
+    - Only useful when changing status to TERMINATED.
+    required: false.
+    type: bool
   disks:
     description:
     - An array of disks that are associated with the instances that are created from
@@ -1112,6 +1118,7 @@ def main():
             state=dict(default='present', choices=['present', 'absent'], type='str'),
             can_ip_forward=dict(type='bool', aliases=['ip_forward']),
             deletion_protection=dict(type='bool'),
+            discard_local_ssd=dict(type='bool', required=False, default=True),
             disks=dict(
                 type='list',
                 elements='dict',
@@ -1506,7 +1513,7 @@ class InstancePower(object):
         return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instances/{name}/start".format(**self.module.params)
 
     def _stop_url(self):
-        return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instances/{name}/stop".format(**self.module.params)
+        return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instances/{name}/stop?discardLocalSsd={discard_local_ssd}".format(**self.module.params)
 
 
 def deletion_protection_update(module, request, response):


### PR DESCRIPTION
##### SUMMARY

If you have an instance with a Local (scratch) SSD attached you need to specify the behavior for this when changing the status to TERMINATED i.e. stopping the instance. Without setting this flag you'll get an error back from the API.

you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
google.cloud.gcp_compute_instance

##### ADDITIONAL INFORMATION
Without the patch, running the following:

```yaml
    - name: set instance status to terminated
      google.cloud.gcp_compute_instance:
        name: "{{ gcp_name }}"
        machine_type: "{{ gcp_instance_type }}"
        status: TERMINATED
        project: "{{ gcp_project }}"
        zone: "{{ gcp_zone }}"
        auth_kind: serviceaccount
        service_account_file: "{{ gcp_sa_file }}"
        deletion_protection: false
        discard_local_ssd: true
      register: _vm

    - ansible.builtin.debug:
        var: _vm
```
Fails with this error:
```
"GCP returned error:
{'error': {
  'code': 400,
  'message': 'VM has a Local SSD attached but an undefined value for `discard-local-ssd`. If using gcloud, please add `--discard-local-ssd=false` or `--discard-local-ssd=true` to your command.',
  'errors': [{
    'message': 'VM has a Local SSD attached but an undefined value for `discard-local-ssd`. If using gcloud, please add `--discard-local-ssd=false` or `--discard-local-ssd=true` to your command.', 
    'domain': 'global',
    'reason': 'badRequest'
  }]
}}"
```

With the patch, the tasks successfully stops the instance