### PR TITLE
Fix an invalid format string on Python 2.7

### DIFF
--- a/plugins/modules/gcp_parameter_manager.py
+++ b/plugins/modules/gcp_parameter_manager.py
@@ -640,7 +640,7 @@ def main():
         fetch['changed'] = changed
         fetch['name'] = module.params.get('name')
     except Exception as e:
-        module.fail_json(msg=f"An unexpected error occurred: {str(e)}")
+        module.fail_json(msg=str(e))
 
     module.exit_json(**fetch)
 


### PR DESCRIPTION
This is causing the 2.7 sanity tests to fail as it's Python 3 syntax.