### PR TITLE
Change a deprecated IAM role in the bootstrap script

### DIFF
--- a/scripts/bootstrap-project.sh
+++ b/scripts/bootstrap-project.sh
@@ -32,7 +32,7 @@ SERVICE_LIST=(
 
 REQUIRED_ROLE_LIST=(
     "roles/storage.objectAdmin"
-    "roles/storage.legacyBucketReader"
+    "roles/storage.bucketViewer"
     "roles/storage.objectCreator"
     "roles/source.admin"
 )


### PR DESCRIPTION
This is causing the integration test GitHub Actions to fail before they even start to run tests.