### PR TITLE
Fix improper names for service_account_contents

### DIFF
--- a/plugins/lookup/gcp_secret_manager.py
+++ b/plugins/lookup/gcp_secret_manager.py
@@ -16,6 +16,10 @@ DOCUMENTATION = '''
       to maintain secrecy of this value once returned.
     - if location option is defined, then it deals with the regional secrets of the
       location
+    requirements:
+    - python >= 2.6
+    - requests >= 2.18.4
+    - google-auth >= 1.3.0
 
     options:
         key:
@@ -60,10 +64,12 @@ DOCUMENTATION = '''
             - see https://cloud.google.com/iam/docs/service-account-creds for details
             type: str
             required: False
-        service_account_info:
+        service_account_contents:
             description:
             - JSON Object representing the contents of a service_account_file obtained from Google Cloud
-            - defaults to OS env variable GCP_SERVICE_ACCOUNT_INFO if not present
+            - defaults to OS env variable GCP_SERVICE_ACCOUNT_CONTENTS if not present
+            aliases:
+            - service_account_info
             type: str
             required: False
         access_token:
@@ -201,7 +207,7 @@ class LookupModule(LookupBase):
         params['name'] = params['key']
 
         # support GCP_* env variables for some parameters
-        for param in ["project", "auth_kind", "service_account_file", "service_account_info", "service_account_email", "access_token"]:
+        for param in ["project", "auth_kind", "service_account_file", "service_account_contents", "service_account_email", "access_token"]:
             params[param] = self.fallback_from_env(param)
 
         self._display.vvv(msg=f"Module Parameters: {params}")


### PR DESCRIPTION
##### SUMMARY

Problem is discribed in #697

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
lookup google.cloud.gcp_secret_manager

##### ADDITIONAL INFORMATION
Before the module didnt apply service_account_contents because it was wrongly named service_account_info. service_account_info is now an alias for service_account_contents.

It is important to note that the service_account_contents will fall back on the environment variable GCP_SERVICE_ACCOUNT_CONTENTS and not GCP_SERVICE_ACCOUNT_INFO. But in my testing the service account token recived from GCP is too big to be stored in an environment variable leaving the fall back useless. I recommend using something like ansible vault to store the service_account_contents to securely retrive the value.

```yml
---
- name: Get a secret from GCP
  hosts: localhost
  gather_facts: false
  vars:
    service_account: '{****************}'
  tasks:
    - name: Get a secret
      ansible.builtin.debug:
        msg: "{{ lookup('google.cloud.gcp_secret_manager', key='test_secret', auth_kind='serviceaccount', service_account_contents=service_account_data, project='*********') }}"
```

before
```
Service Account authentication requires setting either service_account_file or service_account_contents
```
After
```
msg: "test"
```