### PR TITLE
docs: Clarify the type of item expected in ssl_certificates

### DIFF
--- a/plugins/modules/gcp_compute_target_https_proxy.py
+++ b/plugins/modules/gcp_compute_target_https_proxy.py
@@ -298,8 +298,10 @@ quicOverride:
   type: str
 sslCertificates:
   description:
-  - A list of SslCertificate resources that are used to authenticate connections between
-    users and the load balancer. At least one SSL certificate must be specified.
+  - A list of SslCertificate objects (with selfLink and name e.g. as returned by
+    gcp_compute_target_https_proxy_info)  that are used to authenticate
+    connections between users and the load balancer. At least one SSL certificate
+    must be specified.
   returned: success
   type: list
 sslPolicy:


### PR DESCRIPTION
##### SUMMARY
The documentation on gcp_compute_target_https_proxy is a bit ambiguous in the sense that it should not be a list of strings, but a list of objects (dicts)

Fixes #673 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/modules/gcp_compute_target_https_proxy
