### PR TITLE
Update the auto-issue closer workflow

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -10,16 +10,26 @@ jobs:
       - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:
           debug-only: true
-          days-before-stale: -1
-          days-before-close: 180
+          days-before-stale: 180
+          days-before-close: 14
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
+          stale-issue-message: |
+            I'm marking this issue as stale due to inactivity (_180 days_ without response ⏳ ). If there is no activity on it in the next 14 days it will be closed automatically.
+            
+            This helps our maintainers find and focus on active issues.
+
+          stale-pr-message: |
+            I'm marking this pull request as stale due to inactivity (_180 days_ without response ⏳ ). If there is no activity on it in the next 14 days it will be closed automatically.
+            
+            This helps our maintainers find and focus on active contributions.
+
           close-issue-message: |
-            I'm going to close this issue due to inactivity (_180 days_ without response ⏳ ). This helps our maintainers find and focus on the active issues.
+            I'm going to close this issue due to inactivity.
 
             If this issue was automatically closed and you feel this issue should be reopened, please do so with any new available information. Thank you!
 
           close-pr-message: |
-            I'm going to close this pull requests due to inactivity (_180 days_ without response ⏳ ). This helps our maintainers find and focus on the active contributions.
+            I'm going to close this pull request due to inactivity.
 
             If this pull request was automatically closed and you feel this pull request should be reopened, we encourage creating a new pull request linking back to this one for added context. Thank you!


### PR DESCRIPTION
From the dry run logs it looks like I misunderstood how this works - the intention was to close issues and PRs after 180 days of inactivity, but apparently you need to configure it to mark them as stale first. So this config now adds a "stale" label and a comment after 180 days of inactivity, then closes after a further 14 days of inactivity.