### PR TITLE
Remove 2.16 from ansible-integration-tests.yml test matrix

### DIFF
--- a/.github/workflows/ansible-integration-tests.yml
+++ b/.github/workflows/ansible-integration-tests.yml
@@ -25,7 +25,6 @@ jobs:
         # and test against the minimum version of Python supported by both. If/when we change
         # the integration tests to support parallelism we can revisit.
         ansible_version:
-          - stable-2.16
           - stable-2.17
           - stable-2.18
           - stable-2.19


### PR DESCRIPTION
Not for review yet - seeing if this gets us past the current failure
