### PR TITLE
fix: return str on lookup of secret manager

### DIFF
--- a/plugins/lookup/gcp_secret_manager.py
+++ b/plugins/lookup/gcp_secret_manager.py
@@ -213,7 +213,7 @@ class LookupModule(LookupBase):
         self._display.vvv(msg=f"Module Parameters: {params}")
         fake_module = GcpMockModule(params)
         result = self.get_secret(fake_module)
-        return [base64.b64decode(result)]
+        return [base64.b64decode(result).decode("utf-8")]
 
     def fallback_from_env(self, arg):
         if self.get_option(arg):


### PR DESCRIPTION

SUMMARY

Fix the return type of lookup when using the secret manager.
ISSUE TYPE

This returns bytes, when it should return str (the module value returns str)

https://github.com/ansible-collections/google.cloud/blob/master/plugins/modules/gcp_secret_manager.py#L457
