### PR TITLE
Make gcp_alloydb_cluster initial_user required

### DIFF
--- a/plugins/modules/gcp_alloydb_cluster.py
+++ b/plugins/modules/gcp_alloydb_cluster.py
@@ -230,6 +230,7 @@ options:
   initial_user:
     description:
       - Initial user to setup during cluster creation.
+    required: true
     suboptions:
       password:
         description:
@@ -1185,6 +1186,7 @@ def main():
             ),
             initial_user=dict(
                 type="dict",
+                required=True,
                 options=dict(
                     password=dict(
                         type="str",

--- a/tests/integration/targets/gcp_alloydb_backup/tasks/autogen.yml
+++ b/tests/integration/targets/gcp_alloydb_backup/tasks/autogen.yml
@@ -49,6 +49,9 @@
             state: present
             location: us-central1
             cluster_type: PRIMARY
+            initial_user:
+              user: pgroot
+              password: Test123Test
             network_config:
               network: "projects/{{ gcp_project_number }}/global/networks/{{ resource_name }}"
             project: "{{ gcp_project }}"

--- a/tests/integration/targets/gcp_alloydb_cluster/tasks/autogen.yml
+++ b/tests/integration/targets/gcp_alloydb_cluster/tasks/autogen.yml
@@ -28,6 +28,9 @@
             state: present
             location: us-central1
             cluster_type: PRIMARY
+            initial_user:
+              user: pgroot
+              password: Test123Test
             network_config:
               network: "projects/{{ gcp_project_number }}/global/networks/{{ resource_name }}"
             project: "{{ gcp_project }}"
@@ -41,6 +44,9 @@
             state: present
             location: us-central1
             cluster_type: SECONDARY
+            initial_user:
+              user: pgroot
+              password: Test123Test
             network_config:
               network: "projects/{{ gcp_project_number }}/global/networks/{{ resource_name }}"
             secondary_config:


### PR DESCRIPTION
This is now a required field as of today.