### PR TITLE
Add suppression for new 2.21 sanity check

### DIFF
--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -1,4 +1,3 @@
-# https://forum.ansible.com/t/ansible-test-validate-modules-sanity-test-report-bad-return-values-that-cannot-be-accessed-with-jinjas-dot-notation/44833
 plugins/modules/gcp_compute_instance.py validate-modules:bad-return-value-key
 plugins/modules/gcp_compute_instance_info.py validate-modules:bad-return-value-key
 plugins/modules/gcp_compute_instance_template.py validate-modules:bad-return-value-key


### PR DESCRIPTION
We'll need to deal with this eventually, but for now this should allow the CI runs to pass.

https://forum.ansible.com/t/ansible-test-validate-modules-sanity-test-report-bad-return-values-that-cannot-be-accessed-with-jinjas-dot-notation/44833