### PR TITLE
fix: remove type declaration for scp_if_ssh

### DIFF
--- a/plugins/connection/iap.py
+++ b/plugins/connection/iap.py
@@ -262,7 +262,6 @@ DOCUMENTATION = """
       description:
         - Fallback to SCP (Secure Copy Protocol) when SFTP is not available.
         - When enabled and SFTP fails, Ansible will try to use SCP for file transfers.
-      type: bool
       default: smart
       ini:
         - section: ssh_connection


### PR DESCRIPTION
#716 broke documentation due to the `type: bool` declaration on `scp_if_ssh` conflicting with `default: smart`

This results in the following error on the documentation:

```
1 validation error for PluginDocSchema
doc -> options -> scp_if_ssh
  Value error, Invalid value 'smart' for "default": The value 'smart' is not a valid boolean.  Valid booleans include: 'true', 1, 0, 'off', '1', 'y', 'false', '0', 'on', 'no', 't', 'n', 'f', 'yes' (type=value_error; error=Invalid value 'smart' for "default": The value 'smart' is not a valid boolean.  Valid booleans include: 'true', 1, 0, 'off', '1', 'y', 'false', '0', 'on', 'no', 't', 'n', 'f', 'yes')
```

See #728 for more info 