### PR TITLE
Rename compute instance `tags.items` to `tags.tag_values`

### DIFF
--- a/plugins/modules/gcp_compute_instance.py
+++ b/plugins/modules/gcp_compute_instance.py
@@ -1278,6 +1278,8 @@ def update_fields(module, request, response):
         shielded_instance_config_update(module, request, response)
     if response.get('disks') != request.get('disks'):
         extra_disks_update(module, request, response)
+    if response.get('tags') != request.get('tags'):
+        tags_update(module, request, response)
 
 
 def extra_disks_update(module, request, response):
@@ -1320,6 +1322,17 @@ def machine_type_update(module, request, response):
     auth.post(
         ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/zones/{zone}/instances/{name}/setMachineType"]).format(**module.params),
         {u'machineType': machine_type_selflink(module.params.get('machine_type'), module.params)},
+    )
+
+
+def tags_update(module, request, response):
+    tags = tags_encoder(request.get('tags', {}))
+    if response.get('tags') and response.get('tags').get('fingerprint'):
+        tags['fingerprint'] = response.get('tags').get('fingerprint')
+    auth = GcpSession(module, 'compute')
+    auth.post(
+        ''.join(["https://compute.googleapis.com/compute/v1/", "projects/{project}/zones/{zone}/instances/{name}/setTags"]).format(**module.params),
+        tags,
     )
 
 
@@ -1502,12 +1515,16 @@ def raise_if_errors(response, err_path, module):
 def encode_request(request, module):
     if 'metadata' in request and request['metadata'] is not None:
         request['metadata'] = metadata_encoder(request['metadata'])
+    if 'tags' in request and request['tags'] is not None:
+        request['tags'] = tags_encoder(request['tags'])
     return request
 
 
 def decode_response(response, module):
     if 'metadata' in response and response['metadata'] is not None:
         response['metadata'] = metadata_decoder(response['metadata'])
+    if 'tags' in response and response['tags'] is not None:
+        response['tags'] = tags_decoder(response['tags'])
     return response
 
 
@@ -1543,6 +1560,32 @@ def metadata_decoder(metadata):
         for item in metadata_items:
             items[item['key']] = item['value']
     return items
+
+
+def tags_encoder(tags):
+    tags_new = {}
+    if 'fingerprint' in tags:
+        tags_new['fingerprint'] = tags['fingerprint']
+    if 'tag_values' in tags:
+        tags_new['items'] = tags['tag_values']
+    elif 'items' in tags:
+        tags_new['items'] = tags['items']
+    return tags_new
+
+
+def tags_decoder(tags):
+    tags_new = {}
+    if 'fingerprint' in tags:
+        tags_new['fingerprint'] = tags['fingerprint']
+    items = tags.get('items')
+    tag_values = tags.get('tag_values')
+    if tag_values:
+        tags_new['tag_values'] = tag_values
+        tags_new['items'] = tag_values
+    elif items:
+        tags_new['tag_values'] = items
+        tags_new['items'] = deprecate_value(items, 'items is deprecated and will be removed in a future version')
+    return tags_new
 
 
 class InstancePower(object):
@@ -1969,10 +2012,15 @@ class InstanceTags(object):
             self.request = {}
 
     def to_request(self):
+        tag_values = self.request.get('tag_values')
+        if tag_values:
+            return remove_nones_from_dict({
+                u'fingerprint': self.request.get('fingerprint'),
+                u'items': tag_values,
+            })
         return remove_nones_from_dict({
             u'fingerprint': self.request.get('fingerprint'),
-            u'items': deprecate_value(self.request.get('items'), 'items is deprecated and will be removed in a future version'),
-            u'tag_values': self.request.get('items'),
+            u'items': self.request.get('items'),
         })
 
     def from_response(self):

--- a/plugins/modules/gcp_compute_instance.py
+++ b/plugins/modules/gcp_compute_instance.py
@@ -519,6 +519,12 @@ options:
         type: str
       items:
         description:
+        - Deprecated. Use tag_values instead.
+        elements: str
+        required: false
+        type: list
+      tag_values:
+        description:
         - An array of tags. Each tag must be 1-63 characters long, and comply with
           RFC1035.
         elements: str
@@ -1091,7 +1097,7 @@ tags:
         fingerprint hash in order to update or change metadata.
       returned: success
       type: str
-    items:
+    tag_values:
       description:
       - An array of tags. Each tag must be 1-63 characters long, and comply with RFC1035.
       returned: success
@@ -1118,6 +1124,12 @@ from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import (
 import json
 import re
 import time
+
+try:
+    from ansible.module_utils.datatag import deprecate_value
+except ImportError:
+    def deprecate_value(value, msg):
+        pass
 
 ################################################################################
 # Main
@@ -1199,7 +1211,13 @@ def main():
             ),
             confidential_instance_config=dict(type='dict', options=dict(enable_confidential_compute=dict(type='bool'))),
             status=dict(type='str'),
-            tags=dict(type='dict', options=dict(fingerprint=dict(type='str'), items=dict(type='list', elements='str'))),
+            tags=dict(
+                type='dict', options=dict(
+                    fingerprint=dict(type='str'),
+                    tag_values=dict(type='list', elements='str'),
+                    items=dict(type='list', elements='str'),
+                ),
+            ),
             zone=dict(required=True, type='str'),
         )
     )
@@ -1951,7 +1969,11 @@ class InstanceTags(object):
             self.request = {}
 
     def to_request(self):
-        return remove_nones_from_dict({u'fingerprint': self.request.get('fingerprint'), u'items': self.request.get('items')})
+        return remove_nones_from_dict({
+            u'fingerprint': self.request.get('fingerprint'),
+            u'items': deprecate_value(self.request.get('items'), 'items is deprecated and will be removed in a future version'),
+            u'tag_values': self.request.get('items'),
+        })
 
     def from_response(self):
         return remove_nones_from_dict({u'fingerprint': self.request.get(u'fingerprint'), u'items': self.request.get(u'items')})

--- a/plugins/modules/gcp_compute_instance_info.py
+++ b/plugins/modules/gcp_compute_instance_info.py
@@ -588,7 +588,7 @@ resources:
             up-to-date fingerprint hash in order to update or change metadata.
           returned: success
           type: str
-        items:
+        tag_values:
           description:
           - An array of tags. Each tag must be 1-63 characters long, and comply with
             RFC1035.

--- a/plugins/modules/gcp_compute_instance_info.py
+++ b/plugins/modules/gcp_compute_instance_info.py
@@ -679,6 +679,13 @@ def return_if_object(module, response):
     try:
         module.raise_for_status(response)
         result = response.json()
+        if result.items:
+            for instance in result.get('items', []):
+                tags = instance.get('tags')
+                if tags:
+                    items = tags.get('items')
+                    if items:
+                        tags['tag_values'] = items
     except getattr(json.decoder, "JSONDecodeError", ValueError) as inst:
         module.fail_json(msg="Invalid JSON response with error: %s" % inst)
 

--- a/plugins/modules/gcp_compute_instance_template.py
+++ b/plugins/modules/gcp_compute_instance_template.py
@@ -1276,6 +1276,8 @@ def raise_if_errors(response, err_path, module):
 def encode_request(request, module):
     if 'properties' in request and request['properties'] is not None and 'metadata' in request['properties'] and request['properties']['metadata'] is not None:
         request['properties']['metadata'] = metadata_encoder(request['properties']['metadata'])
+    if 'properties' in request and request['properties'] is not None and 'tags' in request['properties'] and request['properties']['tags'] is not None:
+        request['properties']['tags'] = tags_encoder(request['properties']['tags'])
     return request
 
 
@@ -1322,6 +1324,32 @@ def metadata_decoder(metadata):
         for item in metadata_items:
             items[item['key']] = item['value']
     return items
+
+
+def tags_encoder(tags):
+    tags_new = {}
+    if 'fingerprint' in tags:
+        tags_new['fingerprint'] = tags['fingerprint']
+    if 'tag_values' in tags:
+        tags_new['items'] = tags['tag_values']
+    elif 'items' in tags:
+        tags_new['items'] = tags['items']
+    return tags_new
+
+
+def tags_decoder(tags):
+    tags_new = {}
+    if 'fingerprint' in tags:
+        tags_new['fingerprint'] = tags['fingerprint']
+    items = tags.get('items')
+    tag_values = tags.get('tag_values')
+    if tag_values:
+        tags_new['tag_values'] = tag_values
+        tags_new['items'] = tag_values
+    elif items:
+        tags_new['tag_values'] = items
+        tags_new['items'] = deprecate_value(items, 'items is deprecated and will be removed in a future version')
+    return tags_new
 
 
 class InstanceTemplateProperties(object):
@@ -1692,10 +1720,15 @@ class InstanceTemplateTags(object):
             self.request = {}
 
     def to_request(self):
+        tag_values = self.request.get('tag_values')
+        if tag_values:
+            return remove_nones_from_dict({
+                u'fingerprint': self.request.get('fingerprint'),
+                u'items': tag_values,
+            })
         return remove_nones_from_dict({
             u'fingerprint': self.request.get('fingerprint'),
-            u'items': deprecate_value(self.request.get('items'), 'items is deprecated and will be removed in a future version'),
-            u'tag_values': self.request.get('items'),
+            u'items': self.request.get('items'),
         })
 
     def from_response(self):

--- a/plugins/modules/gcp_compute_instance_template.py
+++ b/plugins/modules/gcp_compute_instance_template.py
@@ -467,8 +467,14 @@ options:
             type: str
           items:
             description:
-            - An array of tags. Each tag must be 1-63 characters long, and comply
-              with RFC1035.
+            - Deprecated. Use tag_values instead.
+            elements: str
+            required: false
+            type: list
+          tag_values:
+            description:
+            - An array of tags. Each tag must be 1-63 characters long, and comply with
+              RFC1035.
             elements: str
             required: false
             type: list
@@ -970,7 +976,7 @@ properties:
             up-to-date fingerprint hash in order to update or change metadata.
           returned: success
           type: str
-        items:
+        tag_values:
           description:
           - An array of tags. Each tag must be 1-63 characters long, and comply with
             RFC1035.
@@ -993,6 +999,12 @@ from ansible_collections.google.cloud.plugins.module_utils.gcp_utils import (
 import json
 import re
 import time
+
+try:
+    from ansible.module_utils.datatag import deprecate_value
+except ImportError:
+    def deprecate_value(value, msg):
+        pass
 
 ################################################################################
 # Main
@@ -1072,7 +1084,13 @@ def main():
                         type='dict', options=dict(automatic_restart=dict(type='bool'), on_host_maintenance=dict(type='str'), preemptible=dict(type='bool'))
                     ),
                     service_accounts=dict(type='list', elements='dict', options=dict(email=dict(type='str'), scopes=dict(type='list', elements='str'))),
-                    tags=dict(type='dict', options=dict(fingerprint=dict(type='str'), items=dict(type='list', elements='str'))),
+                    tags=dict(
+                        type='dict', options=dict(
+                            fingerprint=dict(type='str'),
+                            tag_values=dict(type='list', elements='str'),
+                            items=dict(type='list', elements='str'),
+                        ),
+                    ),
                 ),
             ),
         )
@@ -1674,7 +1692,11 @@ class InstanceTemplateTags(object):
             self.request = {}
 
     def to_request(self):
-        return remove_nones_from_dict({u'fingerprint': self.request.get('fingerprint'), u'items': self.request.get('items')})
+        return remove_nones_from_dict({
+            u'fingerprint': self.request.get('fingerprint'),
+            u'items': deprecate_value(self.request.get('items'), 'items is deprecated and will be removed in a future version'),
+            u'tag_values': self.request.get('items'),
+        })
 
     def from_response(self):
         return remove_nones_from_dict({u'fingerprint': self.request.get(u'fingerprint'), u'items': self.request.get(u'items')})

--- a/plugins/modules/gcp_compute_instance_template_info.py
+++ b/plugins/modules/gcp_compute_instance_template_info.py
@@ -540,7 +540,7 @@ resources:
                 metadata.
               returned: success
               type: str
-            items:
+            tag_values:
               description:
               - An array of tags. Each tag must be 1-63 characters long, and comply
                 with RFC1035.

--- a/tests/integration/targets/gcp_compute_instance/tasks/main.yml
+++ b/tests/integration/targets/gcp_compute_instance/tasks/main.yml
@@ -31,6 +31,12 @@
         gcp_disk_image: projects/centos-cloud/global/images/family/centos-stream-9
         gcp_zone: us-central1-a
 
+    - name: Test tags
+      ansible.builtin.include_tasks: tags.yml
+      vars:
+        gcp_disk_image: projects/centos-cloud/global/images/family/centos-stream-9
+        gcp_zone: us-central1-a
+
   always:
     - name: Delete network
       google.cloud.gcp_compute_network:

--- a/tests/integration/targets/gcp_compute_instance/tasks/tags.yml
+++ b/tests/integration/targets/gcp_compute_instance/tasks/tags.yml
@@ -1,0 +1,121 @@
+---
+- block:
+    - name: Create instance using tag_values
+      google.cloud.gcp_compute_instance:
+        name: "{{ resource_name }}-with-tags"
+        machine_type: n1-standard-1
+        state: present
+        disks:
+          - auto_delete: true
+            boot: true
+            initialize_params:
+              source_image: "{{ gcp_disk_image }}"
+              disk_type: pd-standard
+        network_interfaces:
+          - network: "{{ _network }}"
+        zone: "{{ gcp_zone }}"
+        project: "{{ gcp_project }}"
+        auth_kind: "{{ gcp_cred_kind }}"
+        tags:
+          tag_values: ["hello", "world"]
+        service_account_file: "{{ gcp_cred_file | default(omit) }}"
+      register: _result1
+    
+    - name: Show _result1
+      ansible.builtin.debug:
+        var: _result1
+
+    - name: Verify instance info post-create
+      google.cloud.gcp_compute_instance_info:
+        filters:
+          - name = {{ _result1.name }}
+        zone: "{{ gcp_zone }}"
+        project: "{{ gcp_project }}"
+        auth_kind: "{{ gcp_cred_kind }}"
+        service_account_file: "{{ gcp_cred_file | default(omit) }}"
+        scopes:
+          - https://www.googleapis.com/auth/compute
+      register: _info1
+    
+    - name: Show _info1
+      ansible.builtin.debug:
+        var: _info1
+
+    - name: Update instance using items
+      google.cloud.gcp_compute_instance:
+        name: "{{ resource_name }}-with-tags"
+        machine_type: n1-standard-1
+        state: present
+        disks:
+          - auto_delete: true
+            boot: true
+            initialize_params:
+              source_image: "{{ gcp_disk_image }}"
+              disk_type: pd-standard
+        network_interfaces:
+          - network: "{{ _network }}"
+        zone: "{{ gcp_zone }}"
+        project: "{{ gcp_project }}"
+        auth_kind: "{{ gcp_cred_kind }}"
+        tags:
+          items: ["goodbye", "world"]
+        service_account_file: "{{ gcp_cred_file | default(omit) }}"
+      register: _result2
+    
+    - name: Show _result1
+      ansible.builtin.debug:
+        var: _result2
+
+    - name: Verify instance info post-update
+      google.cloud.gcp_compute_instance_info:
+        filters:
+          - name = {{ _result2.name }}
+        zone: "{{ gcp_zone }}"
+        project: "{{ gcp_project }}"
+        auth_kind: "{{ gcp_cred_kind }}"
+        service_account_file: "{{ gcp_cred_file | default(omit) }}"
+        scopes:
+          - https://www.googleapis.com/auth/compute
+      register: _info2
+    
+    - name: Show _info2
+      ansible.builtin.debug:
+        var: _info2
+
+    - name: Run assertions
+      ansible.builtin.assert:
+        that:
+          - _result1.changed == true
+          - _info1.resources | length > 0
+          # tag_values should be set on create
+          - _info1.resources[0].tags.tag_values | length == 2
+          - "'hello' in _info1.resources[0].tags.tag_values"
+          - "'world' in _info1.resources[0].tags.tag_values"
+          # items should be set on create
+          - _info1.resources[0].tags['items'] | length == 2
+          - "'hello' in _info1.resources[0].tags['items']"
+          - "'world' in _info1.resources[0].tags['items']"
+          - _result2.changed == true
+          - _info2.resources | length > 0
+          # tag_values should be set on update
+          - "'tag_values' in _info2.resources[0]['tags']"
+          - _info2.resources[0].tags.tag_values | length == 2
+          - "'goodbye' in _info2.resources[0].tags.tag_values"
+          - "'world' in _info2.resources[0].tags.tag_values"
+          # items should be set on update
+          - "'items' in _info2.resources[0]['tags']"
+          - _info2.resources[0].tags['items'] | length == 2
+          - "'goodbye' in _info2.resources[0].tags['items']"
+          - "'world' in _info2.resources[0].tags['items']"
+
+  always:
+    # teardown
+    - name: Destroy instance
+      google.cloud.gcp_compute_instance:
+        name: "{{ resource_name }}-with-tags"
+        state: absent
+        machine_type: n1-standard-1
+        zone: "{{ gcp_zone }}"
+        project: "{{ gcp_project }}"
+        auth_kind: "{{ gcp_cred_kind }}"
+        service_account_file: "{{ gcp_cred_file | default(omit) }}"

--- a/tests/integration/targets/gcp_compute_instance_template/tasks/autogen.yml
+++ b/tests/integration/targets/gcp_compute_instance_template/tasks/autogen.yml
@@ -47,6 +47,8 @@
             - name: test-config
               type: ONE_TO_ONE_NAT
               nat_ip: "{{ address }}"
+      tags:
+        tag_values: ["hello", "world"]
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
     service_account_file: "{{ gcp_cred_file | default(omit) }}"
@@ -108,6 +110,8 @@
             - name: test-config
               type: ONE_TO_ONE_NAT
               nat_ip: "{{ address }}"
+      tags:
+        items: ["hello", "world"]
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
     service_account_file: "{{ gcp_cred_file | default(omit) }}"

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -1,4 +1,0 @@
-plugins/modules/gcp_compute_instance.py validate-modules:bad-return-value-key
-plugins/modules/gcp_compute_instance_info.py validate-modules:bad-return-value-key
-plugins/modules/gcp_compute_instance_template.py validate-modules:bad-return-value-key
-plugins/modules/gcp_compute_instance_template_info.py validate-modules:bad-return-value-key


### PR DESCRIPTION
The motivation for this PR was to remove the lint suppressions for 2.21 that we had ended up needing [due to a change in the rule set](https://forum.ansible.com/t/ansible-test-validate-modules-sanity-test-report-bad-return-values-that-cannot-be-accessed-with-jinjas-dot-notation/44833) that made reserved names verboten in results.

The two resources changed are `gcp_compute_instance[_info]` and `gcp_compute_instance_template[_info]`, both of which had a `tags.items` field. That field field been renamed to `tags.tag_values`, but the old naming is still supported since dropping it would be a breaking change. Users provide either field name, and both will be returned in results. Using `tags.items` will result in a deprecation warning with 2.19+.

The tags field is now updateable in `gcp_compute_instance` too.