### PR TITLE
Unbreak pubsub integration test

### DIFF
--- a/tests/integration/targets/gcp_pubsub_subscription/tasks/autogen.yml
+++ b/tests/integration/targets/gcp_pubsub_subscription/tasks/autogen.yml
@@ -15,7 +15,7 @@
 # Pre-test setup
 - name: Create a topic
   google.cloud.gcp_pubsub_topic:
-    name: topic-subscription
+    name: "{{ resource_name }}-topic"
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
     service_account_file: "{{ gcp_cred_file | default(omit) }}"
@@ -23,7 +23,17 @@
   register: topic
 - name: Create a bucket
   google.cloud.gcp_storage_bucket:
-    name: topic-subscription-bucket
+    name: "{{ resource_name }}-bucket"
+    project: "{{ gcp_project }}"
+    auth_kind: "{{ gcp_cred_kind }}"
+    service_account_file: "{{ gcp_cred_file | default(omit) }}"
+    state: present
+  register: bucket
+- name: Grant the service account Storage Object Writer role on the bucket
+  google.cloud.gcp_storage_bucket_access_control:
+    bucket: "{{ bucket }}"
+    entity: "user-service-{{ gcp_project_number }}@gcp-sa-pubsub.iam.gserviceaccount.com"
+    role: WRITER
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
     service_account_file: "{{ gcp_cred_file | default(omit) }}"
@@ -101,7 +111,7 @@
     topic: "{{ topic }}"
     ack_deadline_seconds: 300
     cloud_storage: {
-      bucket: "topic-subscription-bucket",
+      bucket: "{{ resource_name }}-bucket",
       file_prefix: "test_",
       file_suffix: "_test",
       max_bytes: 10737418240,
@@ -175,7 +185,7 @@
 
 - name: Delete a bucket
   google.cloud.gcp_storage_bucket:
-    name: topic-subscription-bucket
+    name: "{{ resource_name }}-bucket"
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
     service_account_file: "{{ gcp_cred_file | default(omit) }}"


### PR DESCRIPTION
The fix was adding the `gcp_storage_bucket_access_control` step. The renamings should allow multiple instances of the test to run concurrently.