### PR TITLE
Fix gcp_compute_region_target_http_proxy test and allow concurrency

### DIFF
--- a/tests/integration/targets/gcp_compute_region_target_http_proxy/tasks/autogen.yml
+++ b/tests/integration/targets/gcp_compute_region_target_http_proxy/tasks/autogen.yml
@@ -15,9 +15,9 @@
 # Pre-test setup
 - name: Create a backend service
   google.cloud.gcp_compute_region_backend_service:
-    name: backendservice-targethttpproxy
+    name: "{{ resource_name }}"
     region: us-central1
-    enable_cdn: "true"
+    enable_cdn: "false"
     protocol: HTTP
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
@@ -27,7 +27,7 @@
   register: backendservice
 - name: Create a URL map
   google.cloud.gcp_compute_region_url_map:
-    name: urlmap-targethttpproxy
+    name: "{{ resource_name }}"
     region: us-central1
     default_service: "{{ backendservice }}"
     project: "{{ gcp_project }}"
@@ -139,7 +139,7 @@
 # If errors happen, don't crash the playbook!
 - name: Delete a URL map
   google.cloud.gcp_compute_region_url_map:
-    name: urlmap-targethttpproxy
+    name: "{{ resource_name }}"
     region: us-central1
     default_service: "{{ backendservice }}"
     project: "{{ gcp_project }}"
@@ -149,13 +149,13 @@
   ignore_errors: true # noqa: ignore-errors
 - name: Delete a backend service
   google.cloud.gcp_compute_region_backend_service:
-    name: backendservice-targethttpproxy
+    name: "{{ resource_name }}"
     region: us-central1
-    enable_cdn: "true"
+    enable_cdn: "false"
     protocol: HTTP
     project: "{{ gcp_project }}"
     auth_kind: "{{ gcp_cred_kind }}"
     service_account_file: "{{ gcp_cred_file | default(omit) }}"
     load_balancing_scheme: EXTERNAL
-    state: present
+    state: absent
   ignore_errors: true # noqa: ignore-errors


### PR DESCRIPTION
This fixes the `Invalid value for field 'enableCdn': 'true'.` error.