### PR TITLE
fix(taxonomy): add fallback for unmapped infra_bucket values

### DIFF
--- a/extensions/audit/taxonomy.jq
+++ b/extensions/audit/taxonomy.jq
@@ -72,7 +72,7 @@
       },
       facts: {
         infra_type: "public_cloud",
-        infra_bucket: $actions[$data.action],
+        infra_bucket: ($actions[$data.action] // "unknown"),
         device_type: ($device_type_mapping[$kind] // $kind),
       }
     }


### PR DESCRIPTION
## Summary

- Add `// "unknown"` fallback to `infra_bucket` in `taxonomy.jq` so unmapped modules produce a searchable value instead of null
- Matches the existing fallback pattern used by `device_type` on the adjacent line

Addresses review feedback from @p3ck on #771.