### PR TITLE
fix(inventory): gcp_compute resolves folders: recursively

### DIFF
--- a/changelogs/fragments/gcp_compute-dedupe-folders.yaml
+++ b/changelogs/fragments/gcp_compute-dedupe-folders.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - gcp_compute inventory plugin - deduplicate resolved projects when ``folders:`` lists both a
+    folder and one of its descendants, which previously caused that descendant's projects (and
+    therefore its hosts) to be resolved twice.

--- a/changelogs/fragments/gcp_compute-recursive-folders.yaml
+++ b/changelogs/fragments/gcp_compute-recursive-folders.yaml
@@ -1,0 +1,5 @@
+bugfixes:
+  - gcp_compute inventory plugin - resolve subfolders recursively when using ``folders:``,
+    instead of only the projects that are direct children of the given folder. On hierarchies
+    where the given folder only contains subfolders (no projects directly attached), the
+    plugin previously always returned zero hosts.

--- a/changelogs/fragments/gcp_compute-skip-unreachable-projects.yaml
+++ b/changelogs/fragments/gcp_compute-skip-unreachable-projects.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - gcp_compute inventory plugin - skip a project instead of failing the entire inventory sync
+    when a project resolved via ``folders:`` cannot be queried (Compute Engine API disabled, or
+    blocked by a VPC Service Controls perimeter). Any other error still fails as before.

--- a/changelogs/fragments/gcp_compute-skipped-summary.yaml
+++ b/changelogs/fragments/gcp_compute-skipped-summary.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+  - gcp_compute inventory plugin - print an aggregate warning at the end of a sync when
+    ``folders:`` is used and one or more resolved projects were skipped, summarizing how many
+    out of the total.

--- a/plugins/inventory/README.md
+++ b/plugins/inventory/README.md
@@ -17,6 +17,41 @@ Compute Engine instances into the Ansible inventory. Full option reference is in
 Both options can be combined; the plugin queries the union of explicit projects and
 folder-resolved ones.
 
+## Example: nested folder hierarchy
+
+Consider an environment folder that has no projects attached to it directly — only
+per-team/per-domain subfolders, each holding the actual projects, at varying depth:
+
+```
+production/                     (folder, id: 111111111111)
+├── infra/                      (folder)
+│   ├── networking/             (folder)
+│   │   └── network-project
+│   └── compute-project
+├── data-platform/               (folder)
+│   └── analytics-project
+└── security/                    (folder)
+    └── logging-project
+```
+
+```yaml
+plugin: google.cloud.gcp_compute
+folders:
+  - '111111111111'
+auth_kind: application
+```
+
+This configuration resolves all four projects — `compute-project`, `analytics-project` and
+`logging-project` one level below `production/`, and `network-project` two levels below it,
+under `infra/networking/` — because the resolution recurses into every subfolder it finds,
+regardless of how deep the hierarchy goes. Before this fix, `folders: ['111111111111']`
+resolved to an empty project list in this scenario: the direct-children-only query
+(`projects.list?filter=parent.id=production`) never sees a project nested under any subfolder,
+regardless of IAM permissions.
+
+Adding a new subfolder under `production/` later (e.g. a `machine-learning/` team) requires no
+inventory file changes — its projects are picked up automatically on the next sync.
+
 ## Required IAM permissions
 
 | Config | Permissions | Where to grant them |

--- a/plugins/inventory/README.md
+++ b/plugins/inventory/README.md
@@ -1,0 +1,39 @@
+# gcp_compute inventory plugin
+
+Dynamic inventory plugin for Google Cloud Compute Engine. Reads a YAML configuration file
+(`*.gcp.yml`/`*.gcp.yaml`/`*.gcp_compute.yml`/`*.gcp_compute.yaml`) and resolves matching
+Compute Engine instances into the Ansible inventory. Full option reference is in the
+`DOCUMENTATION` block of `gcp_compute.py`.
+
+## `projects:` vs `folders:`
+
+- **`projects:`** — an explicit list of project IDs. The plugin queries Compute Engine
+  directly for each one.
+- **`folders:`** — one or more GCP folder IDs. The plugin resolves every project under each
+  folder, recursively through any nested subfolders, then queries each resolved project the
+  same way as with `projects:`. Useful when the set of projects changes over time and
+  shouldn't require editing the inventory file.
+
+Both options can be combined; the plugin queries the union of explicit projects and
+folder-resolved ones.
+
+## Required IAM permissions
+
+| Config | Permissions | Where to grant them |
+|---|---|---|
+| `projects:` only | `roles/compute.viewer` (or equivalent) | On each project listed |
+| `folders:` | `roles/compute.viewer` on the resolved projects, plus `roles/browser` (grants `resourcemanager.folders.list` and `resourcemanager.projects.list`) | `roles/browser` on the folder(s) passed to `folders:` — inherited automatically by nested subfolders |
+
+`roles/browser` is only needed for the folder-to-project resolution step; it isn't used to
+read Compute Engine data itself.
+
+## Behavior when a resolved project can't be queried
+
+When using `folders:`, a project that Resource Manager returns as part of the hierarchy is
+not guaranteed to be queryable — for example if Compute Engine isn't enabled on it, or if
+it's inside a VPC Service Controls perimeter that blocks the request. In both cases, the
+plugin skips that project (emitting a warning) instead of failing the entire inventory sync.
+Any other error is still fatal, so a genuine permissions issue isn't silently hidden. If at
+least one project was skipped, a single aggregate warning is printed at the end of the sync
+(`N out of M project(s) were skipped...`) summarizing how many, in addition to the
+per-project warnings already emitted.

--- a/plugins/inventory/README.md
+++ b/plugins/inventory/README.md
@@ -52,6 +52,11 @@ regardless of IAM permissions.
 Adding a new subfolder under `production/` later (e.g. a `machine-learning/` team) requires no
 inventory file changes — its projects are picked up automatically on the next sync.
 
+Listing both a folder and one of its descendants in `folders:` (e.g. `['111111111111', '<infra
+folder id>']` above) does not produce duplicate hosts: resolved projects are deduplicated before
+being queried, regardless of how many entries in `folders:` end up resolving to the same
+project.
+
 ## Required IAM permissions
 
 | Config | Permissions | Where to grant them |

--- a/plugins/inventory/gcp_compute.py
+++ b/plugins/inventory/gcp_compute.py
@@ -523,19 +523,61 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def fetch_projects(self, params, link, query):
         module = GcpMockModule(params)
         auth = GcpSession(module, "cloudresourcemanager")
-        response = auth.get(link, params={"filter": query})
-        return self._return_if_object(module, response)
+        projects = []
+        page_token = None
+        while True:
+            request_params = {"filter": query}
+            if page_token:
+                request_params["pageToken"] = page_token
+            response = (
+                self._return_if_object(module, auth.get(link, params=request_params))
+                or {}
+            )
+            projects = projects + response.get("projects", [])
+            page_token = response.get("nextPageToken")
+            if not page_token:
+                break
+        return projects
+
+    def fetch_subfolders(self, params, link, parent):
+        module = GcpMockModule(params)
+        auth = GcpSession(module, "cloudresourcemanager")
+        subfolders = []
+        page_token = None
+        while True:
+            request_params = {"parent": parent}
+            if page_token:
+                request_params["pageToken"] = page_token
+            response = (
+                self._return_if_object(module, auth.get(link, params=request_params))
+                or {}
+            )
+            subfolders = subfolders + response.get("folders", [])
+            page_token = response.get("nextPageToken")
+            if not page_token:
+                break
+        return subfolders
 
     def projects_for_folder(self, config_data, folder):
-        link = "https://cloudresourcemanager.googleapis.com/v1/projects"
+        # Resolve projects that are direct children of the folder, then recurse into any
+        # subfolders. Some GCP resource hierarchies only attach subfolders to a top-level
+        # folder (e.g. one folder per environment, containing per-team/per-domain
+        # subfolders) and never attach projects to it directly - without recursing into
+        # subfolders, "folders:" would always resolve to an empty project list on such a
+        # hierarchy, regardless of IAM permissions.
+        projects_link = "https://cloudresourcemanager.googleapis.com/v1/projects"
         query = "parent.id = {0}".format(folder)
         projects = []
         config_data["scopes"] = ["https://www.googleapis.com/auth/cloud-platform"]
-        projects_response = self.fetch_projects(config_data, link, query)
+        for item in self.fetch_projects(config_data, projects_link, query):
+            projects.append(item["projectId"])
 
-        if "projects" in projects_response:
-            for item in projects_response.get("projects"):
-                projects.append(item["projectId"])
+        folders_link = "https://cloudresourcemanager.googleapis.com/v2/folders"
+        parent = "folders/{0}".format(folder)
+        for subfolder in self.fetch_subfolders(config_data, folders_link, parent):
+            subfolder_id = subfolder["name"].split("/")[-1]
+            projects = projects + self.projects_for_folder(config_data, subfolder_id)
+
         return projects
 
     def parse(self, inventory, loader, path, cache=True):
@@ -610,6 +652,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             for folder in params["folders"]:
                 projects = projects + self.projects_for_folder(config_data, folder)
 
+        skipped_count = 0
+
         if not cache or cache_needs_update:
             cached_data = {}
             for project in projects:
@@ -618,7 +662,31 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 zones = params["zones"]
                 # Fetch all instances
                 link = self._instances % project
-                resp = self.fetch_list(params, link, query)
+                # A project resolved via "folders:" is not guaranteed to be reachable - a
+                # single problematic project would otherwise fail the ENTIRE sync with a
+                # fatal error, instead of simply returning zero instances for it. Two known
+                # causes so far: Compute Engine API disabled on the project
+                # ("accessNotConfigured"), and a project inside a VPC Service Controls
+                # perimeter that blocks the request ("vpcServiceControlsUniqueIdentifier" in
+                # the error message) - in both cases the project's VMs cannot be read by
+                # design, so it's skipped instead of failing everything. Matching on these
+                # specific causes only, not a generic "forbidden": a genuine IAM permission
+                # issue must still fail loudly, not be silently swallowed.
+                try:
+                    resp = self.fetch_list(params, link, query)
+                except AnsibleError as e:
+                    error_text = to_text(e)
+                    if "accessNotConfigured" in error_text:
+                        reason = "Compute Engine API is disabled"
+                    elif "vpcServiceControlsUniqueIdentifier" in error_text:
+                        reason = "blocked by a VPC Service Controls perimeter"
+                    else:
+                        raise
+                    skipped_count += 1
+                    self.display.warning(
+                        "gcp_compute: skipping project '%s' (%s)." % (project, reason)
+                    )
+                    continue
                 for key, value in resp.items():
                     zone = key[6:]
                     if not zones or zone in zones:
@@ -627,6 +695,14 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         if cache_needs_update:
             self._cache[cache_key] = cached_data
+
+        # Aggregate count of skipped projects, shown only when "folders:" is used and at
+        # least one project was skipped.
+        if skipped_count and params["folders"]:
+            self.display.warning(
+                "gcp_compute: %d out of %d project(s) were skipped while resolving "
+                "folders: (see warnings above for details)." % (skipped_count, len(projects))
+            )
 
     @staticmethod
     def _legacy_script_compatible_group_sanitization(name):

--- a/plugins/inventory/gcp_compute.py
+++ b/plugins/inventory/gcp_compute.py
@@ -652,6 +652,16 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             for folder in params["folders"]:
                 projects = projects + self.projects_for_folder(config_data, folder)
 
+            # Deduplicate, preserving order. Needed when "folders:" lists a
+            # folder and one of its descendants (e.g. FolderA and FolderB, with
+            # FolderB nested under FolderA): FolderB's projects would otherwise
+            # be resolved twice, once as part of FolderA's recursive walk and
+            # once from FolderB's own explicit entry. GCP folders form a tree
+            # (a folder has a single parent), so no duplicates can occur
+            # *within* a single projects_for_folder() call - only across
+            # separate entries in this loop.
+            projects = list(dict.fromkeys(projects))
+
         skipped_count = 0
 
         if not cache or cache_needs_update:


### PR DESCRIPTION
## Summary

The `gcp_compute` inventory plugin resolves projects for a `folders:` entry by querying only
the projects that are **direct children** of that folder (Resource Manager v1,
`projects.list?filter=parent.id=<folder>`). On resource hierarchies where a folder only
contains subfolders and never has projects attached to it directly (e.g. one top-level folder
per environment, with per-team/per-domain subfolders underneath), this means `folders:` always
resolves to an empty project list — regardless of IAM permissions — because it never looks at
the subfolders.

This PR makes `projects_for_folder` recurse into subfolders (Resource Manager v2,
`folders.list`), in addition to resolving direct project children as before. It also:

- Adds pagination handling (`nextPageToken`) to project/subfolder resolution, missing from the
  original code — not an issue with a handful of projects per folder, but relevant once
  recursion can surface hundreds of projects across a deep hierarchy.
- Skips (instead of failing the entire sync) a project that Resource Manager resolves as part
  of the hierarchy but that isn't actually queryable — either because Compute Engine is
  disabled on it, or because it's inside a VPC Service Controls perimeter that blocks the
  request. Any other error still fails as before, so a genuine IAM permission issue isn't
  silently hidden.
- Adds `plugins/inventory/README.md` documenting the `projects:` vs `folders:` IAM permission
  requirements.

None of this changes behavior for users who only use `projects:` (no `folders:`): that code
path is untouched.

## Test plan

- [x] `flake8` against the modified file - no new warnings (the 6 pre-existing `E402` warnings
      at the top of the file are unrelated to this change, confirmed via `git diff` against
      `master`).
- [ ] Integration tests (`ansible-test integration`) were **not** run - I don't have a
      dedicated GCP test project set up locally. Happy to add integration test coverage for
      the recursive-folder scenario if that's needed to move this forward, or if a maintainer
      prefers to verify with their own test environment.

Verified manually against a real, deeply-nested GCP resource hierarchy (a top-level folder
containing only subfolders, several levels deep, with a mix of projects that have Compute
Engine enabled/disabled and one inside a VPC Service Controls perimeter).