### PR TITLE
CI speedup changes

### DIFF
--- a/.github/check-meta.py
+++ b/.github/check-meta.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+
+import difflib
+import glob
+import logging
+import os
+import sys
+
+import yaml
+
+ROOT_DIR: str = os.path.realpath(os.path.join(os.path.dirname(sys.argv[0]), ".."))
+META_DIR: str = os.path.join(ROOT_DIR, "meta")
+MODULE_DIR: str = os.path.join(ROOT_DIR, "plugins", "modules")
+
+
+def check_tombstones(module_files, meta):
+    "Makes sure there aren't any missing tombstones"
+
+    logging.info("Comparing existing tombstones vs action groups")
+    tombstones = []
+    for plugin, routing in meta["plugin_routing"]["modules"].items():
+        if routing.get("tombstone", False):
+            tombstones.append(plugin)
+    tombstones.sort()
+
+    meta_modules = meta["action_groups"]["gcp"]
+    meta_modules.sort()
+
+    warnings = []
+    # if a module is present in action groups but missing from the filesystem
+    # then it means it should be tombstoned
+    for module in meta_modules:
+        if module not in module_files:
+            warnings.append(
+                ValueError(
+                    f"{module} is present in runtime meta but missing "
+                    "from file system, needs tombstone"
+                )
+            )
+
+    return warnings
+
+
+def check_action_groups(module_files, meta):
+    "Makes sure there aren't any missing modules from action_groups"
+
+    logging.info("Comparing existing module files vs action groups")
+
+    meta_modules = meta["action_groups"]["gcp"]
+
+    warnings = []
+    # if a module is present in action groups but missing from the filesystem
+    # then it means it should be tombstoned
+    for module in module_files:
+        if module not in meta_modules:
+            warnings.append(
+                ValueError(
+                    f"{module} file is present in filesystem meta but missing "
+                    "entry in action_groups"
+                )
+            )
+
+    return warnings
+
+
+def diff_action_groups(module_files, meta):
+    "Makes sure action groups defined in meta/runtime.yml match existing files"
+
+    lnbr_modules = [f"{m}\n" for m in module_files]  # for difflib's sake
+    meta_modules = [f"{m}\n" for m in meta["action_groups"]["gcp"]]
+    meta_modules.sort()
+
+    diff = list(
+        difflib.unified_diff(
+            lnbr_modules,
+            meta_modules,
+            fromfile="plugins/modules/*.py",
+            tofile="meta/runtime.yml",
+        )
+    )
+    sys.stdout.writelines(diff)
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    logging.info("Loading plugin filenames from {}".format(MODULE_DIR))
+    warnings = []
+    module_files = []
+    for fn in glob.glob(os.path.join(MODULE_DIR, "*.py")):
+        module_files.append(os.path.basename(os.path.splitext(fn)[0]))
+    module_files.sort()
+
+    logging.info("Loading runtime meta from {}/runtime.yml".format(META_DIR))
+    try:
+        meta = yaml.safe_load(open(os.path.join(META_DIR, "runtime.yml")).read())
+    except Exception as e:
+        logging.error(e)
+        raise
+
+    warnings.extend(check_tombstones(module_files, meta))
+    warnings.extend(check_action_groups(module_files, meta))
+
+    if len(warnings) > 0:
+        for warning in warnings:
+            logging.warning(warning)
+
+        diff_action_groups(module_files, meta)
+
+        raise RuntimeError("Encountered errors in runtime meta")
+
+    logging.info("Done.")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ansible-integration-tests.yml
+++ b/.github/workflows/ansible-integration-tests.yml
@@ -19,10 +19,6 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
 jobs:
   setup:
-    if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     env:
       # only need to change this one stanza to use the same
@@ -34,6 +30,37 @@ jobs:
       - id: set-python
         run: |
           echo "version=$PYTHON" >> $GITHUB_OUTPUT
+
+  filter:
+    runs-on: ubuntu-latest
+    env:
+      PR_BODY: ${{ github.event.pull_request.body }}
+    outputs:
+      targets: ${{ steps.match.outputs.targets }}
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          fetch-depth: 0
+      - id: match
+        name: Filter integration tests targets
+        run: |
+          set -ex
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            echo "targets=cloud/gcp/" >> "$GITHUB_OUTPUT"  # run the full integration test on merge
+          else
+            echo "" > /tmp/integration_targets.txt
+            # fetch modified modules
+            git diff --name-only --diff-filter=ACMRT ..origin/master -- plugins/modules/ | grep -v '_info.py' | while read line
+            do
+              echo "$(basename $line .py)"
+            done >> /tmp/integration_targets.txt
+            # fetch modified integration tests
+            git diff --name-only --diff-filter=ACMRT ..origin/master -- tests/integration/ | cut -d'/' -f4 >> /tmp/integration_targets.txt
+            # fetch supplied targets in test-hints
+            echo "$PR_BODY" | grep -i "^test-hints:" | grep -i "targets=" | tr ',' ' ' | cut -d'=' -f2 >> /tmp/integration_targets.txt
+            echo "targets=$(grep . /tmp/integration_targets.txt | sort | uniq | paste -s -d' ') cloud/gcp/teardown/" >> "$GITHUB_OUTPUT"
+          fi
 
   integration:
     # NOTE: GitHub does not allow secrets to be used
@@ -47,7 +74,9 @@ jobs:
     defaults:
       run:
         working-directory: ansible_collections/google/cloud
-    needs: setup
+    needs:
+      - setup
+      - filter
     strategy:
       max-parallel: 1
       matrix:
@@ -106,4 +135,4 @@ jobs:
       # run tests
       - name: Run integration tests
         # Add the -vvv flag to print out more output
-        run: ansible-test integration -vvv --color --python ${{ needs.setup.outputs.python }} --venv-system-site-packages
+        run: ansible-test integration -vvv --color --python ${{ needs.setup.outputs.python }} --venv-system-site-packages ${{ needs.filter.outputs.targets }}

--- a/.github/workflows/ansible-integration-tests.yml
+++ b/.github/workflows/ansible-integration-tests.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - master
+    paths:
+      - 'plugins/**'
+      - 'tests/integration/targets/**'
 env:
   GCP_SERVICE_ACCOUNT: github-ci@ansible-gcp-ci.iam.gserviceaccount.com
   GCP_PROJECT: ansible-gcp-ci

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -9,6 +9,8 @@ on:
       - main
       - stable-*
   pull_request:
+    paths:
+      - 'plugins/**'
   # Run CI once per day (at 06:00 UTC)
   # This ensures that even if there haven't been commits that we are still
   # testing against latest version of ansible-test for each ansible-core

--- a/.github/workflows/collection-health.yml
+++ b/.github/workflows/collection-health.yml
@@ -1,0 +1,14 @@
+---
+name: Collection health checks
+on:
+  pull_request:
+    paths:
+      - 'meta/**'
+      - 'plugins/modules/**'
+jobs:
+  check-meta:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - id: python-check-meta
+        run: python .github/check-meta.py

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -48,9 +48,13 @@ plugin_routing:
 action_groups:
   gcp:
     - gcp_alloydb_backup
+    - gcp_alloydb_backup_info
     - gcp_alloydb_cluster
+    - gcp_alloydb_cluster_info
     - gcp_alloydb_instance
+    - gcp_alloydb_instance_info
     - gcp_alloydb_user
+    - gcp_alloydb_user_info
     - gcp_appengine_firewall_rule
     - gcp_appengine_firewall_rule_info
     - gcp_bigquery_dataset
@@ -62,13 +66,23 @@ action_groups:
     - gcp_cloudbuild_trigger
     - gcp_cloudbuild_trigger_info
     - gcp_cloudbuildv2_connection
+    - gcp_cloudbuildv2_connection_info
     - gcp_cloudbuildv2_repository
+    - gcp_cloudbuildv2_repository_info
     - gcp_cloudfunctions_cloud_function
     - gcp_cloudfunctions_cloud_function_info
     - gcp_cloudscheduler_job
     - gcp_cloudscheduler_job_info
     - gcp_cloudtasks_queue
     - gcp_cloudtasks_queue_info
+    - gcp_colab_notebook_execution
+    - gcp_colab_notebook_execution_info
+    - gcp_colab_runtime
+    - gcp_colab_runtime_info
+    - gcp_colab_runtime_template
+    - gcp_colab_runtime_template_info
+    - gcp_colab_schedule
+    - gcp_colab_schedule_info
     - gcp_compute_address
     - gcp_compute_address_info
     - gcp_compute_autoscaler
@@ -219,3 +233,36 @@ action_groups:
     - gcp_storage_object
     - gcp_tpu_node
     - gcp_tpu_node_info
+    - gcp_vertexai_dataset
+    - gcp_vertexai_dataset_info
+    - gcp_vertexai_deployment_resource_pool
+    - gcp_vertexai_deployment_resource_pool_info
+    - gcp_vertexai_endpoint
+    - gcp_vertexai_endpoint_info
+    - gcp_vertexai_endpoint_with_model_garden_deployment
+    - gcp_vertexai_feature_group
+    - gcp_vertexai_feature_group_feature
+    - gcp_vertexai_feature_group_feature_info
+    - gcp_vertexai_feature_group_info
+    - gcp_vertexai_feature_online_store
+    - gcp_vertexai_feature_online_store_featureview
+    - gcp_vertexai_feature_online_store_featureview_info
+    - gcp_vertexai_feature_online_store_info
+    - gcp_vertexai_featurestore
+    - gcp_vertexai_featurestore_entitytype
+    - gcp_vertexai_featurestore_entitytype_feature
+    - gcp_vertexai_featurestore_entitytype_feature_info
+    - gcp_vertexai_featurestore_entitytype_info
+    - gcp_vertexai_featurestore_info
+    - gcp_vertexai_index
+    - gcp_vertexai_index_endpoint
+    - gcp_vertexai_index_endpoint_deployed_index
+    - gcp_vertexai_index_endpoint_info
+    - gcp_vertexai_index_info
+    - gcp_vertexai_metadata_store
+    - gcp_vertexai_metadata_store_info
+    - gcp_vertexai_rag_engine_config
+    - gcp_vertexai_reasoning_engine
+    - gcp_vertexai_reasoning_engine_info
+    - gcp_vertexai_tensorboard
+    - gcp_vertexai_tensorboard_info

--- a/tests/integration/targets/setup_test_network/defaults/main.yml
+++ b/tests/integration/targets/setup_test_network/defaults/main.yml
@@ -1,0 +1,1 @@
+resource_name: "{{ resource_prefix }}"

--- a/tests/integration/targets/setup_test_network/tasks/main.yml
+++ b/tests/integration/targets/setup_test_network/tasks/main.yml
@@ -1,0 +1,8 @@
+  - name: Create test network
+    google.cloud.gcp_compute_network:
+      name: "{{ resource_name }}"
+      state: present
+      auto_create_subnetworks: true
+      project: "{{ gcp_project }}"
+      auth_kind: "{{ gcp_cred_kind }}"
+      service_account_file: "{{ gcp_cred_file }}"

--- a/tests/integration/targets/setup_vpc_peering/defaults/main.yml
+++ b/tests/integration/targets/setup_vpc_peering/defaults/main.yml
@@ -1,0 +1,1 @@
+resource_name: "{{ resource_prefix }}"

--- a/tests/integration/targets/setup_vpc_peering/tasks/main.yml
+++ b/tests/integration/targets/setup_vpc_peering/tasks/main.yml
@@ -1,0 +1,62 @@
+- name: Create peering range address
+  google.cloud.gcp_compute_global_address:
+    name: "{{ resource_name }}-peering"
+    state: present
+    address_type: INTERNAL
+    prefix_length: 16
+    purpose: VPC_PEERING
+    network:
+      selfLink: "https://www.googleapis.com/compute/v1/projects/{{ gcp_project }}/global/networks/{{ resource_name }}"
+    project: "{{ gcp_project }}"
+    auth_kind: "{{ gcp_cred_kind }}"
+    service_account_file: "{{ gcp_cred_file }}"
+
+- name: Connect VPC peering service
+  block:
+    - name: Create temporary directory
+      ansible.builtin.tempfile:
+        state: directory
+      register: _tempdir
+
+    - name: Activate service account
+      environment:
+        CLOUDSDK_CONFIG: "{{ _tempdir.path }}"
+        GOOGLE_APPLICATION_CREDENTIALS: "{{ gcp_cred_file }}"
+      ansible.builtin.command: |
+        gcloud auth activate-service-account --key-file="$GOOGLE_APPLICATION_CREDENTIALS"
+
+    - name: Check for vpc-peering service
+      environment:
+        CLOUDSDK_CONFIG: "{{ _tempdir.path }}"
+        GOOGLE_APPLICATION_CREDENTIALS: "{{ gcp_cred_file }}"
+      ansible.builtin.command: |
+        gcloud services vpc-peerings list \
+            --service=servicenetworking.googleapis.com \
+            --network="{{ resource_name }}" \
+            --project="{{ gcp_project }}"
+      register: _vpc_peering_check
+      failed_when: false
+      changed_when: false
+
+    - name: Connect vpc-peering service
+      environment:
+        CLOUDSDK_CONFIG: "{{ _tempdir.path }}"
+        GOOGLE_APPLICATION_CREDENTIALS: "{{ gcp_cred_file }}"
+      ansible.builtin.command: |
+        gcloud services vpc-peerings connect \
+            --quiet \
+            --service=servicenetworking.googleapis.com \
+            --ranges="{{ resource_name }}-peering" \
+            --network="{{ resource_name }}" \
+            --project="{{ gcp_project }}"
+      when: _vpc_peering_check.stdout | length == 0
+      register: _vpc_peering_connect
+      failed_when:
+        - "'finished successfully' not in _vpc_peering_connect.stderr"
+      changed_when: true
+
+  always:
+    - name: Delete temporary directory
+      ansible.builtin.file:
+        path: "{{ _tempdir.path }}"
+        state: absent

--- a/tests/integration/targets/zz_teardown_01_vpc_peering/aliases
+++ b/tests/integration/targets/zz_teardown_01_vpc_peering/aliases
@@ -1,0 +1,2 @@
+cloud/gcp
+cloud/gcp/teardown

--- a/tests/integration/targets/zz_teardown_01_vpc_peering/defaults/main.yml
+++ b/tests/integration/targets/zz_teardown_01_vpc_peering/defaults/main.yml
@@ -1,0 +1,1 @@
+resource_name: "{{ resource_prefix }}"

--- a/tests/integration/targets/zz_teardown_01_vpc_peering/tasks/main.yml
+++ b/tests/integration/targets/zz_teardown_01_vpc_peering/tasks/main.yml
@@ -1,0 +1,44 @@
+- name: Disconnect VPC peering service
+  block:
+    - name: Create temporary directory
+      ansible.builtin.tempfile:
+        state: directory
+      register: _tempdir
+
+    - name: Activate service account
+      environment:
+        CLOUDSDK_CONFIG: "{{ _tempdir.path }}"
+        GOOGLE_APPLICATION_CREDENTIALS: "{{ gcp_cred_file }}"
+      ansible.builtin.command: |
+        gcloud auth activate-service-account --key-file="$GOOGLE_APPLICATION_CREDENTIALS"
+
+    - name: Delete vpc-peering service
+      environment:
+        CLOUDSDK_CONFIG: "{{ _tempdir.path }}"
+        GOOGLE_APPLICATION_CREDENTIALS: "{{ gcp_cred_file }}"
+      ansible.builtin.command: |
+        gcloud services vpc-peerings delete \
+            --service=servicenetworking.googleapis.com \
+            --network="{{ resource_name }}" \
+            --project="{{ gcp_project }}"
+      changed_when: true
+      failed_when: false
+
+  always:
+    - name: Delete temporary directory
+      ansible.builtin.file:
+        path: "{{ _tempdir.path }}"
+        state: absent
+
+- name: Delete peering range address
+  google.cloud.gcp_compute_global_address:
+    name: "{{ resource_name }}-peering"
+    state: absent
+    address_type: INTERNAL
+    prefix_length: 16
+    purpose: VPC_PEERING
+    network:
+      selfLink: "https://www.googleapis.com/compute/v1/projects/{{ gcp_project }}global/networks/{{ resource_name }}"
+    project: "{{ gcp_project }}"
+    auth_kind: "{{ gcp_cred_kind }}"
+    service_account_file: "{{ gcp_cred_file }}"

--- a/tests/integration/targets/zz_teardown_02_test_network/aliases
+++ b/tests/integration/targets/zz_teardown_02_test_network/aliases
@@ -1,0 +1,2 @@
+cloud/gcp
+cloud/gcp/teardown

--- a/tests/integration/targets/zz_teardown_02_test_network/defaults/main.yml
+++ b/tests/integration/targets/zz_teardown_02_test_network/defaults/main.yml
@@ -1,0 +1,1 @@
+resource_name: "{{ resource_prefix }}"

--- a/tests/integration/targets/zz_teardown_02_test_network/tasks/main.yml
+++ b/tests/integration/targets/zz_teardown_02_test_network/tasks/main.yml
@@ -1,0 +1,7 @@
+  - name: Destroy test network
+    google.cloud.gcp_compute_network:
+      name: "{{ resource_name }}"
+      state: absent
+      project: "{{ gcp_project }}"
+      auth_kind: "{{ gcp_cred_kind }}"
+      service_account_file: "{{ gcp_cred_file }}"

--- a/tests/integration/targets/zz_teardown_03_bigquery_dataset/aliases
+++ b/tests/integration/targets/zz_teardown_03_bigquery_dataset/aliases
@@ -1,0 +1,2 @@
+cloud/gcp
+cloud/gcp/teardown

--- a/tests/integration/targets/zz_teardown_03_bigquery_dataset/defaults/main.yml
+++ b/tests/integration/targets/zz_teardown_03_bigquery_dataset/defaults/main.yml
@@ -1,0 +1,1 @@
+resource_name: "{{ resource_prefix }}"

--- a/tests/integration/targets/zz_teardown_03_bigquery_dataset/tasks/main.yml
+++ b/tests/integration/targets/zz_teardown_03_bigquery_dataset/tasks/main.yml
@@ -1,0 +1,9 @@
+- name: Delete BigQuery Dataset
+  google.cloud.gcp_bigquery_dataset:
+    state: absent
+    name: "{{ resource_name | regex_replace('-', '_') }}"
+    dataset_reference:
+      dataset_id: "{{ resource_name | regex_replace('-', '_') }}"
+    project: "{{ gcp_project }}"
+    auth_kind: "{{ gcp_cred_kind }}"
+    service_account_file: "{{ gcp_cred_file }}"


### PR DESCRIPTION
##### SUMMARY
* Perform a few checks whenever plugin modules are updated to make sure meta/runtime.yml is always up to date. Should keep issues like #773 from popping up
* Adds a set of setup_ targets that can be directly called from other targets meta dependencies
* Adds a set of teardown_ targets, these cannot be automatically run but there is a group cloud/gcp/teardown/ that includes these
* Adds a filtering step to the integration tests GHA to only run the modified targets, optionally can read test hints from the PR body

##### ISSUE TYPE
- Bugfix/enhancement

##### COMPONENT NAME
CI

Test-Hints: targets=inventory_gce